### PR TITLE
Slice 7: audio_tts Modality + Fish-Speech simple + voice-clone (#9)

### DIFF
--- a/core/modalities/__init__.py
+++ b/core/modalities/__init__.py
@@ -10,6 +10,7 @@ The :mod:`core.modalities.registry` module exposes a global
 ``ModalityRegistry`` instance so the bot can dispatch by Modality.
 """
 
+from core.modalities.audio_tts.plugin import AudioTTSPlugin
 from core.modalities.base import (
     ModalityPlugin,
     ProgressMapper,
@@ -21,6 +22,7 @@ from core.modalities.image_upscale.plugin import ImageUpscalePlugin
 from core.modalities.registry import ModalityRegistry, default_registry
 
 __all__ = [
+    "AudioTTSPlugin",
     "ImageT2IPlugin",
     "ImageUpscalePlugin",
     "ModalityPlugin",

--- a/core/modalities/audio_common.py
+++ b/core/modalities/audio_common.py
@@ -1,0 +1,407 @@
+"""Shared audio helpers for the audio_tts and audio_music Plugins.
+
+This module is **Plugin-agnostic** by design: nothing here knows about
+Fish-Speech, ACE-Step, or any other model. It packages an audio file
+for Discord, extracts a duration, transcodes when ComfyUI emits a
+non-MP3, and renders a small monochrome waveform PNG preview.
+
+ADR anchors:
+
+- ADR-0007 mandates "MP3 + duration label + waveform preview" for the
+  audio Modalities and notes that ``imageio-ffmpeg`` is already a
+  transitive dep, so we shell out to its bundled binary when the host
+  has neither ``ffprobe`` nor a system ``ffmpeg`` on ``$PATH``.
+- ADR-0002 says Plugins do not know about specific models; this module
+  encodes that boundary for audio packaging.
+
+ffmpeg / ffprobe handling:
+
+The bot may run on hosts with no ffmpeg / ffprobe on ``$PATH`` (Docker
+slim images, fresh dev VMs). All subprocess calls are fail-soft:
+
+- Duration extraction returns ``-1.0`` and logs a warning if no ffprobe
+  / ffmpeg is found.
+- Transcoding raises :class:`AudioToolingMissing` so the caller can
+  fall back to delivering the original audio with a friendly note.
+- Waveform rendering returns ``None`` when ffmpeg is unavailable; the
+  Plugin then posts only the audio file, no preview attachment.
+
+The shared :class:`AudioPackage` dataclass is what each Plugin's
+renderer returns to the bot layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import struct
+import subprocess
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DISCORD_AUDIO_SIZE_LIMIT_BYTES: int = 25 * 1024 * 1024
+"""Discord's per-file attachment cap for free / non-boosted servers."""
+
+DEFAULT_WAVEFORM_WIDTH: int = 600
+DEFAULT_WAVEFORM_HEIGHT: int = 100
+
+_DURATION_RE = re.compile(
+    r"Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)", re.IGNORECASE
+)
+
+
+class AudioToolingMissing(RuntimeError):
+    """Raised when an operation needs ffmpeg / ffprobe and neither is present."""
+
+
+@dataclass(frozen=True)
+class AudioPackage:
+    """A Discord-ready bundle for one audio output.
+
+    A Plugin renderer constructs one of these per audio Output:
+
+    - ``filename`` / ``content_type`` / ``data``: the audio file itself
+      ready to attach to a Discord message.
+    - ``duration_seconds``: best-effort length probe; ``-1.0`` means
+      the host is missing ffmpeg / ffprobe and the Plugin should label
+      the duration as "unknown" rather than block.
+    - ``waveform_png``: a small monochrome PNG preview, or ``None`` if
+      ffmpeg was unavailable / the audio could not be decoded.
+    - ``oversize``: the file exceeds Discord's 25 MB cap. The Plugin
+      should NOT attach ``data`` in that case; instead it can post a
+      stub message pointing to the on-disk path.
+    """
+
+    filename: str
+    content_type: str
+    data: bytes
+    duration_seconds: float
+    waveform_png: bytes | None
+    oversize: bool = False
+
+    @property
+    def size_bytes(self) -> int:
+        return len(self.data)
+
+    def duration_label(self) -> str:
+        """Return a human-friendly mm:ss label, or 'unknown'."""
+        if self.duration_seconds < 0:
+            return "unknown"
+        total = int(round(self.duration_seconds))
+        m, s = divmod(total, 60)
+        if m >= 60:
+            h, m = divmod(m, 60)
+            return f"{h}:{m:02d}:{s:02d}"
+        return f"{m}:{s:02d}"
+
+
+def package_for_discord(
+    audio_path: Path,
+    mime: str,
+    *,
+    waveform_width: int = DEFAULT_WAVEFORM_WIDTH,
+    waveform_height: int = DEFAULT_WAVEFORM_HEIGHT,
+) -> AudioPackage:
+    """Build an :class:`AudioPackage` from an on-disk audio file.
+
+    The returned package always has ``data`` populated (even when
+    ``oversize`` is ``True``) so the Plugin can decide whether to
+    attach the bytes or post a stub. ``waveform_png`` is omitted for
+    oversize files to save work.
+    """
+    audio_path = Path(audio_path)
+    data = audio_path.read_bytes()
+    duration = extract_duration_seconds(audio_path)
+    oversize = len(data) > DISCORD_AUDIO_SIZE_LIMIT_BYTES
+    waveform: bytes | None = None
+    if not oversize:
+        try:
+            waveform = render_waveform_png(
+                audio_path, width=waveform_width, height=waveform_height
+            )
+        except Exception as e:  # noqa: BLE001 - waveform is decorative
+            logger.warning(
+                "waveform render failed for %s: %s; posting without preview",
+                audio_path,
+                e,
+            )
+            waveform = None
+    return AudioPackage(
+        filename=audio_path.name,
+        content_type=mime,
+        data=data,
+        duration_seconds=duration,
+        waveform_png=waveform,
+        oversize=oversize,
+    )
+
+
+def extract_duration_seconds(audio_path: Path) -> float:
+    """Best-effort audio duration in seconds.
+
+    Tries, in order:
+
+    1. ``ffprobe`` on ``$PATH`` (cheapest + most accurate).
+    2. ``ffmpeg -i`` (system or imageio-bundled), parsing
+       ``Duration: HH:MM:SS.ms`` from stderr.
+    3. Python stdlib :mod:`wave` for ``.wav`` containers.
+
+    Returns ``-1.0`` and logs a warning if every method fails. The
+    Plugin renderer should treat negative values as "unknown".
+    """
+    audio_path = Path(audio_path)
+    if not audio_path.is_file():
+        logger.warning("extract_duration_seconds: %s not found", audio_path)
+        return -1.0
+
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe:
+        try:
+            out = subprocess.run(
+                [
+                    ffprobe,
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    str(audio_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            if out.returncode == 0:
+                value = out.stdout.strip()
+                if value:
+                    return float(value)
+        except (subprocess.TimeoutExpired, ValueError, OSError) as e:
+            logger.warning("ffprobe failed for %s: %s; falling back", audio_path, e)
+
+    ffmpeg = _find_ffmpeg()
+    if ffmpeg:
+        try:
+            proc = subprocess.run(
+                [ffmpeg, "-hide_banner", "-i", str(audio_path)],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            stderr = proc.stderr or ""
+            match = _DURATION_RE.search(stderr)
+            if match:
+                hours, minutes, seconds = match.groups()
+                return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+        except (subprocess.TimeoutExpired, OSError) as e:
+            logger.warning("ffmpeg duration probe failed for %s: %s", audio_path, e)
+
+    if audio_path.suffix.lower() in (".wav", ".wave"):
+        try:
+            with wave.open(str(audio_path), "rb") as w:
+                frames = w.getnframes()
+                rate = w.getframerate() or 0
+                if rate > 0:
+                    return frames / float(rate)
+        except (wave.Error, OSError, EOFError) as e:
+            logger.warning("wave fallback failed for %s: %s", audio_path, e)
+
+    logger.warning(
+        "no ffprobe/ffmpeg available; duration unknown for %s", audio_path
+    )
+    return -1.0
+
+
+def transcode_to_mp3(input_path: Path, *, output_path: Path | None = None) -> Path:
+    """Transcode any ffmpeg-readable audio to a 192k MP3.
+
+    Used when a manifest's downstream node emits WAV (e.g. plain
+    ``SaveAudio`` instead of ``SaveAudioMP3``). Writes alongside the
+    input by default (``foo.wav`` -> ``foo.mp3``).
+
+    Raises:
+        AudioToolingMissing: no ffmpeg available on the host.
+        RuntimeError: ffmpeg returned a non-zero exit.
+    """
+    input_path = Path(input_path)
+    if not input_path.is_file():
+        raise FileNotFoundError(input_path)
+    ffmpeg = _find_ffmpeg()
+    if not ffmpeg:
+        raise AudioToolingMissing(
+            "ffmpeg not available on PATH and imageio-ffmpeg lookup failed; "
+            "cannot transcode to MP3"
+        )
+    out = output_path if output_path is not None else input_path.with_suffix(".mp3")
+    out = Path(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(input_path),
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "192k",
+            str(out),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg transcode failed: {proc.stderr.strip()[:500]}"
+        )
+    return out
+
+
+def render_waveform_png(
+    audio_path: Path,
+    *,
+    width: int = DEFAULT_WAVEFORM_WIDTH,
+    height: int = DEFAULT_WAVEFORM_HEIGHT,
+) -> bytes | None:
+    """Render a tiny monochrome waveform preview as PNG bytes.
+
+    Decodes the audio to mono int16 PCM via ffmpeg, downsamples into
+    ``width`` peak/trough pairs, and draws the silhouette in black on
+    a white background using PIL. Returns ``None`` if ffmpeg is
+    unavailable - the bot then posts the audio file alone, no preview.
+
+    Args:
+        audio_path: input audio (anything ffmpeg can read).
+        width: output PNG width in pixels.
+        height: output PNG height in pixels.
+    """
+    audio_path = Path(audio_path)
+    ffmpeg = _find_ffmpeg()
+    if not ffmpeg:
+        logger.warning(
+            "render_waveform_png: no ffmpeg, skipping waveform for %s", audio_path
+        )
+        return None
+    if width <= 0 or height <= 0:
+        raise ValueError("width/height must be positive")
+
+    sample_rate = 8000
+    proc = subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(audio_path),
+            "-ac",
+            "1",
+            "-ar",
+            str(sample_rate),
+            "-f",
+            "s16le",
+            "-",
+        ],
+        capture_output=True,
+        timeout=60,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        logger.warning(
+            "render_waveform_png: ffmpeg decode failed for %s (%s)",
+            audio_path,
+            (proc.stderr or b"").decode("utf-8", "replace")[:200],
+        )
+        return None
+
+    raw = proc.stdout
+    sample_count = len(raw) // 2
+    if sample_count == 0:
+        return None
+    samples = struct.unpack(f"<{sample_count}h", raw[: sample_count * 2])
+
+    return _draw_waveform_png(samples, width=width, height=height)
+
+
+def _draw_waveform_png(samples, *, width: int, height: int) -> bytes:
+    """Bin samples into ``width`` columns, draw silhouette, return PNG."""
+    from io import BytesIO
+
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (width, height), (255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    sample_count = len(samples)
+    if sample_count == 0:
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+
+    bin_size = max(sample_count // width, 1)
+    mid_y = height // 2
+    max_amp = 32768
+    for col in range(width):
+        start = col * bin_size
+        end = start + bin_size
+        if start >= sample_count:
+            break
+        chunk = samples[start:end]
+        if not chunk:
+            continue
+        peak_pos = max(chunk)
+        peak_neg = min(chunk)
+        top_y = int(mid_y - (peak_pos / max_amp) * mid_y)
+        bot_y = int(mid_y - (peak_neg / max_amp) * mid_y)
+        if top_y == bot_y:
+            top_y -= 1
+            bot_y += 1
+        draw.line([(col, top_y), (col, bot_y)], fill=(20, 20, 20))
+
+    draw.line([(0, mid_y), (width - 1, mid_y)], fill=(180, 180, 180))
+
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _find_ffmpeg() -> str | None:
+    """Return a path to an ffmpeg executable, or ``None``.
+
+    Order:
+
+    1. ``ffmpeg`` on ``$PATH`` (system install).
+    2. ``imageio_ffmpeg.get_ffmpeg_exe()`` (already a dependency for
+       video frame export, ADR-0007).
+    """
+    path = shutil.which("ffmpeg")
+    if path:
+        return path
+    try:
+        import imageio_ffmpeg  # type: ignore[import-untyped]
+
+        exe = imageio_ffmpeg.get_ffmpeg_exe()
+        if exe and Path(exe).is_file():
+            return exe
+    except Exception as e:  # noqa: BLE001 - any failure -> fallback to None
+        logger.debug("imageio_ffmpeg lookup failed: %s", e)
+    return None
+
+
+__all__ = [
+    "AudioPackage",
+    "AudioToolingMissing",
+    "DEFAULT_WAVEFORM_HEIGHT",
+    "DEFAULT_WAVEFORM_WIDTH",
+    "DISCORD_AUDIO_SIZE_LIMIT_BYTES",
+    "extract_duration_seconds",
+    "package_for_discord",
+    "render_waveform_png",
+    "transcode_to_mp3",
+]

--- a/core/modalities/audio_tts/__init__.py
+++ b/core/modalities/audio_tts/__init__.py
@@ -1,0 +1,11 @@
+"""Audio text-to-speech Plugin (ADR-0002, ADR-0007).
+
+Drives Fish-Speech S2 manifests today; will host any future TTS
+manifest the operator drops in (e.g. KugelAudio, Chatterbox) with no
+code change. Reference-audio uploads are supported via the AUDIO Slot
+type so VoiceClone manifests work end-to-end.
+"""
+
+from core.modalities.audio_tts.plugin import AudioTTSPlugin
+
+__all__ = ["AudioTTSPlugin"]

--- a/core/modalities/audio_tts/plugin.py
+++ b/core/modalities/audio_tts/plugin.py
@@ -1,0 +1,338 @@
+"""AudioTTS Modality Plugin (ADR-0002, ADR-0007).
+
+Modality contract:
+
+- ``output_media``: ``["audio/mpeg"]``. Manifests must declare an MP3
+  output (typically via ``SaveAudioMP3``); WAV-emitting workflows are
+  expected to chain through :func:`core.modalities.audio_common.transcode_to_mp3`
+  before the renderer is invoked.
+- Validator: coerces TEXT / SEED / ENUM slots through the shared helper
+  and applies manifest ``validation`` rules. AUDIO slots accept either
+  a filesystem path string or a ``{filename, mime, data}`` dict (so the
+  bot can hand attached Discord uploads straight through).
+- ProgressMapper: TTS is single-pass; some Fish-Speech versions emit
+  step events, some don't. The mapper reports 5% on first executing
+  event, mirrors any explicit ``progress`` events linearly, and pins
+  100% on ``ExecutionComplete`` / ``Executing(node=None)``. Monotone.
+- Renderer: posts the MP3 as a Discord attachment plus a duration label
+  embed and (when ffmpeg is available) a waveform PNG preview.
+- Default actions: respects the Manifest's declared Actions verbatim.
+  v3.0 manifests ship with no audio Actions; future re-roll buttons
+  will be authored in YAML.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from core.manifest.roles import Modality, Role
+from core.manifest.schema import Action, Manifest, SlotType
+from core.modalities.audio_common import (
+    AudioPackage,
+    package_for_discord,
+)
+from core.modalities.base import (
+    ProgressMapper,
+    SlotValueValidationError,
+    SlotValues,
+    coerce_slot_values_against_manifest,
+    enforce_validation_rules,
+)
+from core.run import DiscordFile, DiscordPayload, Output, Run
+
+WAVEFORM_FILENAME_TEMPLATE = "{stem}_waveform.png"
+"""Filename pattern used for the optional waveform preview attachment."""
+
+_ACCEPTED_AUDIO_DICT_KEYS = {"filename", "mime", "data"}
+
+
+class _SinglePassProgressMapper:
+    """Simple monotone progress for single-pass TTS workflows.
+
+    Strategy:
+
+    - ``Reconnected`` / unrelated events: return ``None`` (no change).
+    - First ``Executing`` for a real node: 5% (lets the user see *something*
+      while Fish-Speech loads its checkpoint).
+    - ``Progress`` events on any node: scale ``value/max`` into the
+      remaining 5..95% band and report monotone.
+    - ``ExecutionComplete`` or ``Executing(node=None)``: 100%.
+    """
+
+    def __init__(self) -> None:
+        self._last_pct: int | None = None
+        self._seen_node_executing: bool = False
+        self._complete: bool = False
+
+    def update(self, event: Any) -> int | None:
+        from core.comfyui.v3.ws import (
+            Executing,
+            ExecutionComplete,
+            Progress,
+            Reconnected,
+        )
+
+        if isinstance(event, Reconnected):
+            return self._last_pct
+
+        if isinstance(event, ExecutionComplete):
+            self._complete = True
+            return self._maybe_set(100)
+
+        if isinstance(event, Executing):
+            if event.node is None and event.prompt_id:
+                self._complete = True
+                return self._maybe_set(100)
+            if not self._seen_node_executing:
+                self._seen_node_executing = True
+                return self._maybe_set(5)
+            return None
+
+        if isinstance(event, Progress):
+            max_steps = max(int(event.max), 1)
+            value = max(0, min(int(event.value), max_steps))
+            band_pct = int(5 + (value / max_steps) * 90)
+            return self._maybe_set(band_pct)
+
+        return None
+
+    def _maybe_set(self, pct: int) -> int | None:
+        pct = max(0, min(100, pct))
+        if self._last_pct is not None and pct < self._last_pct:
+            pct = self._last_pct
+        if pct == self._last_pct:
+            return None
+        self._last_pct = pct
+        return pct
+
+
+class AudioTTSPlugin:
+    """Plugin for the ``audio_tts`` Modality. ADR-0002 contract."""
+
+    modality: Modality = Modality.AUDIO_TTS
+    output_media: list[str] = ["audio/mpeg"]
+
+    async def validate_slot_values(
+        self, manifest: Manifest, values: SlotValues
+    ) -> SlotValues:
+        coerced = coerce_slot_values_against_manifest(manifest, values)
+        coerced = self._coerce_audio_slots(manifest, coerced)
+        enforce_validation_rules(manifest, coerced)
+        self._enforce_audio_mime_accepts(manifest, coerced)
+        return coerced
+
+    def progress_mapper(self) -> ProgressMapper:
+        return _SinglePassProgressMapper()
+
+    async def render_outputs(
+        self, run: Run, outputs: list[Output]
+    ) -> DiscordPayload:
+        audio_outputs = [o for o in outputs if o.role == Role.OUTPUT_AUDIO]
+        files: list[DiscordFile] = []
+        durations: list[str] = []
+        oversize_notes: list[str] = []
+
+        for o in audio_outputs:
+            try:
+                pkg = package_for_discord(o.path, o.media)
+            except FileNotFoundError:
+                pkg = AudioPackage(
+                    filename=o.filename,
+                    content_type=o.media,
+                    data=o.bytes_read,
+                    duration_seconds=-1.0,
+                    waveform_png=None,
+                    oversize=len(o.bytes_read) > 25 * 1024 * 1024,
+                )
+
+            durations.append(pkg.duration_label())
+
+            if pkg.oversize:
+                oversize_notes.append(
+                    f"{pkg.filename} is {_human_bytes(pkg.size_bytes)} "
+                    f"(over Discord's 25 MB cap); not attached."
+                )
+                continue
+
+            files.append(
+                DiscordFile(
+                    filename=pkg.filename,
+                    content_type=pkg.content_type,
+                    data=pkg.data,
+                )
+            )
+            if pkg.waveform_png is not None:
+                files.append(
+                    DiscordFile(
+                        filename=WAVEFORM_FILENAME_TEMPLATE.format(
+                            stem=Path(pkg.filename).stem
+                        ),
+                        content_type="image/png",
+                        data=pkg.waveform_png,
+                    )
+                )
+
+        embed = self._build_embed(run, durations, audio_outputs)
+        if oversize_notes:
+            note = "\n".join(oversize_notes)
+            existing = embed.get("description") or ""
+            embed["description"] = (existing + "\n" + note).strip() if existing else note
+
+        return DiscordPayload(embed=embed, files=files)
+
+    def default_post_actions(self, manifest: Manifest) -> list[Action]:
+        return list(manifest.actions)
+
+    def _coerce_audio_slots(
+        self, manifest: Manifest, values: SlotValues
+    ) -> SlotValues:
+        slots = manifest.slots_by_name()
+        out: SlotValues = dict(values)
+        for name, raw in list(values.items()):
+            slot = slots.get(name)
+            if slot is None or slot.type != SlotType.AUDIO:
+                continue
+            out[name] = self._coerce_one_audio_value(name, raw)
+        return out
+
+    def _coerce_one_audio_value(self, slot_name: str, raw: Any) -> Any:
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            return raw
+        if isinstance(raw, Path):
+            return str(raw)
+        if isinstance(raw, dict):
+            unknown = set(raw) - _ACCEPTED_AUDIO_DICT_KEYS
+            if unknown:
+                raise SlotValueValidationError(
+                    slot_name,
+                    f"audio dict has unexpected keys: {sorted(unknown)}; "
+                    f"expected subset of {sorted(_ACCEPTED_AUDIO_DICT_KEYS)}",
+                )
+            if "filename" not in raw or "data" not in raw:
+                raise SlotValueValidationError(
+                    slot_name,
+                    "audio dict must include at least 'filename' and 'data'",
+                )
+            if not isinstance(raw["filename"], str):
+                raise SlotValueValidationError(
+                    slot_name, "audio dict 'filename' must be a string"
+                )
+            if not isinstance(raw["data"], (bytes, bytearray)):
+                raise SlotValueValidationError(
+                    slot_name, "audio dict 'data' must be bytes"
+                )
+            mime = raw.get("mime")
+            if mime is not None and not isinstance(mime, str):
+                raise SlotValueValidationError(
+                    slot_name, "audio dict 'mime' must be a string"
+                )
+            return {
+                "filename": raw["filename"],
+                "mime": mime or "application/octet-stream",
+                "data": bytes(raw["data"]),
+            }
+        raise SlotValueValidationError(
+            slot_name,
+            f"unsupported value for audio slot: {type(raw).__name__}; "
+            "expected str path, pathlib.Path, or {filename, mime, data} dict",
+        )
+
+    def _enforce_audio_mime_accepts(
+        self, manifest: Manifest, values: SlotValues
+    ) -> None:
+        slots = manifest.slots_by_name()
+        for name, value in values.items():
+            slot = slots.get(name)
+            if slot is None or slot.type != SlotType.AUDIO:
+                continue
+            if slot.validation is None or not slot.validation.accepts:
+                continue
+            if not isinstance(value, dict):
+                continue
+            mime = value.get("mime")
+            if not mime:
+                continue
+            accepts = [a.lower() for a in slot.validation.accepts]
+            if mime.lower() not in accepts:
+                raise SlotValueValidationError(
+                    name,
+                    f"mime '{mime}' is not accepted; expected one of {accepts}",
+                )
+
+    def _build_embed(
+        self,
+        run: Run,
+        durations: list[str],
+        audio_outputs: list[Output],
+    ) -> dict[str, Any]:
+        fields: list[dict[str, Any]] = []
+        text = run.slot_values.get("text") or run.slot_values.get("prompt")
+        if text:
+            fields.append(
+                {
+                    "name": "Text",
+                    "value": _truncate(str(text), 1024),
+                    "inline": False,
+                }
+            )
+        if durations:
+            fields.append(
+                {
+                    "name": "Duration",
+                    "value": ", ".join(durations),
+                    "inline": True,
+                }
+            )
+        seed = run.slot_values.get("seed")
+        if seed is not None:
+            fields.append({"name": "Seed", "value": str(seed), "inline": True})
+        voice_ref = run.slot_values.get("voice_reference")
+        if voice_ref:
+            fields.append(
+                {
+                    "name": "Voice reference",
+                    "value": _audio_label(voice_ref),
+                    "inline": True,
+                }
+            )
+        embed: dict[str, Any] = {
+            "title": run.manifest_id,
+            "color": 0x5865F2,
+            "fields": fields,
+            "footer": {
+                "text": f"prompt_id: {run.prompt_id}" if run.prompt_id else ""
+            },
+        }
+        if audio_outputs:
+            stem = Path(audio_outputs[0].filename).stem
+            preview_name = WAVEFORM_FILENAME_TEMPLATE.format(stem=stem)
+            embed["image"] = {"url": f"attachment://{preview_name}"}
+        return embed
+
+
+def _truncate(s: str, limit: int) -> str:
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "\u2026"
+
+
+def _human_bytes(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024**2:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024**2):.1f} MB"
+
+
+def _audio_label(value: Any) -> str:
+    if isinstance(value, dict):
+        return str(value.get("filename", "<audio>"))
+    if isinstance(value, (str, Path)):
+        return Path(str(value)).name
+    return "<audio>"
+
+
+__all__ = ["AudioTTSPlugin"]

--- a/core/modalities/registry.py
+++ b/core/modalities/registry.py
@@ -51,9 +51,10 @@ def _wire_default_plugins() -> None:
     """Register every Plugin that ships in v3.
 
     Imported here to avoid import cycles between Plugin modules and the
-    registry. Slice 1 ships only ``image_t2i``; later slices append to
+    registry. Each new Modality slice appends one ``register`` call to
     this function.
     """
+    from core.modalities.audio_tts.plugin import AudioTTSPlugin
     from core.modalities.image_t2i.plugin import ImageT2IPlugin
     from core.modalities.image_upscale.plugin import ImageUpscalePlugin
     from core.modalities.video.plugin import VideoPlugin
@@ -61,6 +62,7 @@ def _wire_default_plugins() -> None:
     default_registry.register(ImageT2IPlugin())
     default_registry.register(ImageUpscalePlugin())
     default_registry.register(VideoPlugin())
+    default_registry.register(AudioTTSPlugin())
 
 
 _wire_default_plugins()

--- a/docs/v3/smoke/SLICE_9_RUNS.md
+++ b/docs/v3/smoke/SLICE_9_RUNS.md
@@ -1,0 +1,77 @@
+# Slice 9 (issue #9) - audio_tts smoke runs
+
+**Branch:** `slice/9-fish-tts`
+**Modality:** `audio_tts`
+**Manifests under test:**
+- `audio_tts_fish_simple` (`workflows/audio_tts_fish_simple.json`)
+- `audio_tts_fish_voiceclone` (`workflows/audio_tts_fish_voiceclone.json`)
+
+**ComfyUI target:** `http://172.27.1.165:8188`
+
+## Status: TODO_SMOKE - DEFERRED
+
+Live ComfyUI was not reachable from the agent worktree at the time of
+this slice. The TCP probe to `172.27.1.165:8188` timed out twice during
+the slice (once before implementation, once before smoke).
+
+Per `AGENTS.md` ("Never skip the live smoke") and the slice
+instructions ("If ComfyUI unreachable: defer per the standard rule"),
+the live smoke is deferred. The smoke must be run by the maintainer
+(or a follow-up agent on a network with access to the ComfyUI host)
+before merging this PR.
+
+### Reproducing the smoke when ComfyUI is reachable
+
+```bash
+source venv/bin/activate
+
+# Simple Fish-Speech TTS (uses the built-in s2-pro voice).
+python scripts/v3_smoke.py \
+  --manifest audio_tts_fish_simple \
+  --slot text="Hello world, this is a Fish-Speech tracer-bullet smoke." \
+  --slot seed=42
+
+# Voice-clone Fish-Speech TTS.
+# Provide a 5-30s reference clip; the helper line below makes a short
+# 440Hz sine reference if no real clip is available.
+ffmpeg -y -f lavfi -i sine=frequency=440:duration=5 /tmp/ref.wav
+
+python scripts/v3_smoke.py \
+  --manifest audio_tts_fish_voiceclone \
+  --slot text="Voice-cloning tracer bullet via Fish-Speech S2." \
+  --slot voice_reference=/tmp/ref.wav \
+  --slot seed=7
+```
+
+### What to capture
+
+For each run, fill in a row in the table below before merging:
+
+| run | manifest | prompt_id | output_path | bytes | duration_s | latency_s |
+| --- | --- | --- | --- | --- | --- | --- |
+| simple | audio_tts_fish_simple | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+| voiceclone | audio_tts_fish_voiceclone | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+### Acceptance evidence
+
+- [ ] `audio_tts_fish_simple` smoke produced an MP3 under `output/v3_smoke/<prompt_id>/`.
+- [ ] `audio_tts_fish_voiceclone` smoke uploaded the reference audio
+      via `upload_audio` and produced an MP3 in the cloned voice.
+- [ ] Both runs reported a non-negative duration in `package_for_discord`.
+- [ ] No `model_type`/`DyPE`/`hidream`/`krea` strings introduced in code.
+
+## Notes for the live smoke runner
+
+- `core/modalities/audio_common.py` ships ffmpeg-aware duration probing
+  and waveform PNG rendering. On a host without ffmpeg / ffprobe, the
+  duration falls back to a `wave` stdlib probe for WAV files (returns
+  `-1.0` for MP3/FLAC) and waveform rendering returns `None`. The
+  Plugin tolerates both cases - the Discord embed shows `Duration:
+  unknown` and posts the audio without a preview.
+- `imageio-ffmpeg` is already a transitive dep and bundles a private
+  ffmpeg binary; `audio_common._find_ffmpeg` falls back to it when
+  `$PATH` has no ffmpeg.
+- `scripts/v3_smoke.py` now uploads any `audio` Slot whose value
+  resolves to a local file before queuing the workflow, replacing the
+  override with the filename ComfyUI assigned. Already-uploaded names
+  (no path separator, file not present locally) are passed through.

--- a/scripts/v3_smoke.py
+++ b/scripts/v3_smoke.py
@@ -220,6 +220,18 @@ async def run_smoke(
             raise SmokeError(f"image slot upload failed: {e}") from e
 
         try:
+            slot_overrides = await _resolve_audio_inputs(
+                http=http,
+                manifest=manifest,
+                slot_overrides=slot_overrides,
+                logger=logger,
+            )
+        except SmokeError:
+            raise
+        except Exception as e:
+            raise SmokeError(f"audio upload preprocess failed: {e}") from e
+
+        try:
             coerced = await plugin.validate_slot_values(manifest, slot_overrides)
         except Exception as e:
             raise SmokeError(f"slot validation failed: {e}") from e
@@ -465,15 +477,90 @@ async def _collect_outputs(
     return collected
 
 
+_AUDIO_EXT_MIME = {
+    ".wav": "audio/wav",
+    ".wave": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".oga": "audio/ogg",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+    ".opus": "audio/opus",
+}
+
+
+async def _resolve_audio_inputs(
+    *,
+    http: "ComfyHTTPClient",
+    manifest: Manifest,
+    slot_overrides: dict[str, Any],
+    logger: logging.Logger,
+) -> dict[str, Any]:
+    """Upload any local path supplied for an AUDIO Slot, swap in the filename.
+
+    For each manifest Slot with ``type: audio``, a string value is
+    interpreted as a local filesystem path. The file is read, uploaded
+    via the v3 client's ``upload_audio`` (alias for ``/upload/image``
+    with audio mimes per ADR-0007), and the override is replaced with
+    the filename ComfyUI assigned. Already-uploaded names (no path
+    separator and no existing file) are passed through unchanged so
+    operators can reference inputs they previously uploaded.
+    """
+    slots = manifest.slots_by_name()
+    out: dict[str, Any] = dict(slot_overrides)
+    for name, raw in list(slot_overrides.items()):
+        slot = slots.get(name)
+        if slot is None or slot.type != SlotType.AUDIO:
+            continue
+        if not isinstance(raw, str):
+            continue
+        path = Path(raw).expanduser()
+        if not path.is_file():
+            if "/" not in raw and "\\" not in raw:
+                logger.info(
+                    "audio slot '%s' value %r looks like an existing ComfyUI input; using verbatim",
+                    name,
+                    raw,
+                )
+                continue
+            raise SmokeError(
+                f"audio slot '{name}' references missing file: {path}"
+            )
+        data = path.read_bytes()
+        ext = path.suffix.lower()
+        content_type = _AUDIO_EXT_MIME.get(ext, "application/octet-stream")
+        try:
+            resp = await http.upload_audio(
+                filename=path.name,
+                data=data,
+                content_type=content_type,
+            )
+        except ComfyHTTPError as e:
+            raise SmokeError(
+                f"upload_audio failed for slot '{name}' ({path}): {e}"
+            ) from e
+        uploaded = resp.get("name") or path.name
+        logger.info(
+            "uploaded audio slot '%s': %s -> %s (%d bytes)",
+            name,
+            path,
+            uploaded,
+            len(data),
+        )
+        out[name] = uploaded
+    return out
+
+
 def _candidate_buckets_for_media(media: str) -> list[str]:
     """Map a manifest MIME to ComfyUI history bucket keys, in priority order.
 
     Different ComfyUI nodes use different keys for the same output kind:
     SaveImage uses ``images``; the legacy VHS_VideoCombine custom node
     emits MP4 / WebM under ``gifs`` (historical naming) and newer builds
-    may also expose ``videos``. We try all plausible names per Modality
-    so the smoke harness does not need to know which node authored the
-    output.
+    may also expose ``videos``. Audio nodes commonly use ``audio``.
+    We try all plausible names per Modality so the smoke harness does
+    not need to know which node authored the output.
     """
     if media.startswith("image/"):
         return ["images"]

--- a/tests/test_audio_common.py
+++ b/tests/test_audio_common.py
@@ -1,0 +1,183 @@
+"""Tests for :mod:`core.modalities.audio_common`.
+
+Three behaviours under test:
+
+- ``extract_duration_seconds`` returns a real number for a WAV fixture
+  (always works via the stdlib ``wave`` fallback) and ``-1.0`` when no
+  audio tooling can decode the file at all.
+- ``render_waveform_png`` produces a valid PNG header (or ``None`` on
+  hosts without ffmpeg).
+- ``package_for_discord`` builds an :class:`AudioPackage` whose
+  ``duration_label`` is well-formed and whose oversize flag flips at
+  the 25 MB Discord cap.
+
+A tiny mono 16-bit WAV fixture is generated via :mod:`wave` so the
+tests run on hosts without ffmpeg / ffprobe.
+"""
+
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+from core.modalities import audio_common
+from core.modalities.audio_common import (
+    AudioPackage,
+    DISCORD_AUDIO_SIZE_LIMIT_BYTES,
+    AudioToolingMissing,
+    extract_duration_seconds,
+    package_for_discord,
+    render_waveform_png,
+    transcode_to_mp3,
+)
+
+
+def _write_sine_wav(path: Path, *, duration_s: float = 0.5, freq: float = 440.0) -> Path:
+    """Write a tiny mono 16-bit sine WAV to ``path``."""
+    sample_rate = 8000
+    n_samples = int(sample_rate * duration_s)
+    import math
+
+    frames = bytearray()
+    for i in range(n_samples):
+        amp = int(0.4 * 32767 * math.sin(2 * math.pi * freq * i / sample_rate))
+        frames.extend(struct.pack("<h", amp))
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(bytes(frames))
+    return path
+
+
+@pytest.fixture
+def sine_wav(tmp_path: Path) -> Path:
+    return _write_sine_wav(tmp_path / "sine.wav", duration_s=0.5)
+
+
+@pytest.fixture
+def long_wav(tmp_path: Path) -> Path:
+    return _write_sine_wav(tmp_path / "long.wav", duration_s=2.5)
+
+
+class TestExtractDurationSeconds:
+    def test_wave_fallback_returns_duration(self, sine_wav: Path) -> None:
+        d = extract_duration_seconds(sine_wav)
+        assert d == pytest.approx(0.5, abs=0.05)
+
+    def test_returns_negative_for_missing_file(self, tmp_path: Path) -> None:
+        d = extract_duration_seconds(tmp_path / "nope.wav")
+        assert d == -1.0
+
+    def test_no_tooling_returns_negative(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Force the all-fail path: garbage extension + no tooling."""
+        garbage = tmp_path / "noaudio.bin"
+        garbage.write_bytes(b"not really audio")
+
+        monkeypatch.setattr(audio_common.shutil, "which", lambda name: None)
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+
+        assert extract_duration_seconds(garbage) == -1.0
+
+
+class TestRenderWaveformPng:
+    def test_returns_none_when_no_ffmpeg(
+        self, sine_wav: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        assert render_waveform_png(sine_wav) is None
+
+    def test_validates_dimensions(self, sine_wav: Path) -> None:
+        with pytest.raises(ValueError):
+            render_waveform_png(sine_wav, width=0, height=10)
+
+
+class TestDrawWaveformPng:
+    def test_draws_valid_png(self) -> None:
+        samples = [int(32767 * (i % 100 - 50) / 50) for i in range(2000)]
+        png = audio_common._draw_waveform_png(samples, width=200, height=40)
+        assert png[:8] == b"\x89PNG\r\n\x1a\n"
+        assert len(png) > 100
+
+    def test_handles_empty(self) -> None:
+        png = audio_common._draw_waveform_png([], width=50, height=20)
+        assert png[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class TestPackageForDiscord:
+    def test_packages_small_wav_without_ffmpeg(
+        self,
+        sine_wav: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        pkg = package_for_discord(sine_wav, "audio/wav")
+        assert isinstance(pkg, AudioPackage)
+        assert pkg.filename == "sine.wav"
+        assert pkg.content_type == "audio/wav"
+        assert pkg.data == sine_wav.read_bytes()
+        assert pkg.oversize is False
+        assert pkg.waveform_png is None
+        assert pkg.duration_seconds > 0
+        assert pkg.duration_label() == "0:00" or pkg.duration_label() == "0:01"
+
+    def test_oversize_flag_skips_waveform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"\x00" * (DISCORD_AUDIO_SIZE_LIMIT_BYTES + 16))
+
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        pkg = package_for_discord(big, "audio/mpeg")
+        assert pkg.oversize is True
+        assert pkg.waveform_png is None
+
+    def test_duration_label_unknown_for_negative(self) -> None:
+        pkg = AudioPackage(
+            filename="x.mp3",
+            content_type="audio/mpeg",
+            data=b"",
+            duration_seconds=-1.0,
+            waveform_png=None,
+        )
+        assert pkg.duration_label() == "unknown"
+
+    def test_duration_label_minutes_seconds(self) -> None:
+        pkg = AudioPackage(
+            filename="x.mp3",
+            content_type="audio/mpeg",
+            data=b"",
+            duration_seconds=125.4,
+            waveform_png=None,
+        )
+        assert pkg.duration_label() == "2:05"
+
+    def test_duration_label_hours_minutes_seconds(self) -> None:
+        pkg = AudioPackage(
+            filename="x.mp3",
+            content_type="audio/mpeg",
+            data=b"",
+            duration_seconds=3725,
+            waveform_png=None,
+        )
+        assert pkg.duration_label() == "1:02:05"
+
+
+class TestTranscodeToMp3:
+    def test_raises_when_no_ffmpeg(
+        self,
+        sine_wav: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        with pytest.raises(AudioToolingMissing):
+            transcode_to_mp3(sine_wav)
+
+    def test_raises_for_missing_input(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            transcode_to_mp3(tmp_path / "nope.wav")

--- a/tests/test_audio_manifest_loading.py
+++ b/tests/test_audio_manifest_loading.py
@@ -1,0 +1,106 @@
+"""Tests covering the two audio_tts manifests authored in Slice 7.
+
+These guard against accidental schema regressions: that the YAML on
+disk parses, that key facts (modality, output mime, voice-clone slot
+shape) are preserved, and that the registry routes the modality to
+the AudioTTSPlugin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+from core.manifest.schema import SlotType
+from core.modalities import default_registry
+from core.modalities.audio_tts.plugin import AudioTTSPlugin
+
+
+@pytest.fixture
+def simple_manifest():
+    return load_manifest("workflows/manifests/audio_tts_fish_simple.yaml")
+
+
+@pytest.fixture
+def voiceclone_manifest():
+    return load_manifest("workflows/manifests/audio_tts_fish_voiceclone.yaml")
+
+
+class TestSimpleManifest:
+    def test_modality_is_audio_tts(self, simple_manifest) -> None:
+        assert simple_manifest.modality == Modality.AUDIO_TTS
+
+    def test_output_is_mp3(self, simple_manifest) -> None:
+        assert len(simple_manifest.outputs) == 1
+        assert simple_manifest.outputs[0].role == Role.OUTPUT_AUDIO
+        assert simple_manifest.outputs[0].media == "audio/mpeg"
+
+    def test_text_slot_required(self, simple_manifest) -> None:
+        slots = simple_manifest.slots_by_name()
+        assert "text" in slots
+        text_slot = slots["text"]
+        assert text_slot.type == SlotType.TEXT
+        assert text_slot.ui.required is True
+
+    def test_seed_slot_present(self, simple_manifest) -> None:
+        slots = simple_manifest.slots_by_name()
+        assert "seed" in slots
+        assert slots["seed"].type == SlotType.SEED
+
+    def test_requires_fish_pack(self, simple_manifest) -> None:
+        assert "custom_nodes.ComfyUI-FishAudioS2" in simple_manifest.requires.packs
+
+    def test_no_actions(self, simple_manifest) -> None:
+        assert simple_manifest.actions == []
+
+
+class TestVoiceCloneManifest:
+    def test_modality_is_audio_tts(self, voiceclone_manifest) -> None:
+        assert voiceclone_manifest.modality == Modality.AUDIO_TTS
+
+    def test_voice_reference_slot_audio_required(self, voiceclone_manifest) -> None:
+        slots = voiceclone_manifest.slots_by_name()
+        assert "voice_reference" in slots
+        slot = slots["voice_reference"]
+        assert slot.type == SlotType.AUDIO
+        assert slot.role == Role.REFERENCE_AUDIO
+        assert slot.ui.required is True
+        assert slot.ui.attachment_position == 1
+
+    def test_voice_reference_accepts_listed(self, voiceclone_manifest) -> None:
+        slots = voiceclone_manifest.slots_by_name()
+        accepts = slots["voice_reference"].validation.accepts
+        assert accepts is not None
+        assert "audio/wav" in accepts
+        assert "audio/mpeg" in accepts
+
+    def test_text_slot_is_long_text(self, voiceclone_manifest) -> None:
+        slots = voiceclone_manifest.slots_by_name()
+        from core.manifest.schema import UIHint
+
+        assert slots["text"].ui.hint == UIHint.LONG_TEXT
+
+    def test_output_is_mp3(self, voiceclone_manifest) -> None:
+        assert voiceclone_manifest.outputs[0].media == "audio/mpeg"
+
+    def test_requires_fish_pack(self, voiceclone_manifest) -> None:
+        assert (
+            "custom_nodes.ComfyUI-FishAudioS2"
+            in voiceclone_manifest.requires.packs
+        )
+
+
+class TestRegistryWiring:
+    def test_audio_tts_modality_resolves_to_plugin(
+        self, simple_manifest
+    ) -> None:
+        plugin = default_registry.get(simple_manifest.modality)
+        assert isinstance(plugin, AudioTTSPlugin)
+        assert plugin.modality == Modality.AUDIO_TTS
+
+    def test_voiceclone_modality_resolves_to_plugin(
+        self, voiceclone_manifest
+    ) -> None:
+        plugin = default_registry.get(voiceclone_manifest.modality)
+        assert isinstance(plugin, AudioTTSPlugin)

--- a/tests/test_audio_tts_plugin.py
+++ b/tests/test_audio_tts_plugin.py
@@ -1,0 +1,364 @@
+"""Tests for the audio_tts Modality Plugin (ADR-0002, ADR-0007).
+
+Three seams under test:
+
+- ``validate_slot_values`` coerces TEXT / SEED / AUDIO slot values,
+  enforces manifest validation rules including ``accepts`` mime
+  filters, and rejects shape-bad audio dicts.
+- The progress mapper produces a monotone 0..100 sequence covering
+  the ``Executing`` / ``Progress`` / ``ExecutionComplete`` events
+  Fish-Speech surfaces in practice.
+- ``render_outputs`` builds a :class:`DiscordPayload` with the MP3
+  attachment, a duration label, and (when ffmpeg is available) a
+  waveform preview attachment.
+
+No live ComfyUI; no Discord runtime.
+"""
+
+from __future__ import annotations
+
+import struct
+import uuid
+import wave
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.ws import (
+    Executing,
+    ExecutionComplete,
+    Progress,
+    Reconnected,
+)
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+from core.modalities import audio_common
+from core.modalities.audio_tts.plugin import AudioTTSPlugin
+from core.modalities.base import SlotValueValidationError
+from core.run import Output, Run, RunStatus
+
+
+@pytest.fixture
+def simple_manifest():
+    return load_manifest("workflows/manifests/audio_tts_fish_simple.yaml")
+
+
+@pytest.fixture
+def voiceclone_manifest():
+    return load_manifest("workflows/manifests/audio_tts_fish_voiceclone.yaml")
+
+
+@pytest.fixture
+def plugin() -> AudioTTSPlugin:
+    return AudioTTSPlugin()
+
+
+def _write_tiny_wav(path: Path) -> Path:
+    import math
+
+    sample_rate = 8000
+    n = sample_rate // 4
+    frames = bytearray()
+    for i in range(n):
+        amp = int(0.3 * 32767 * math.sin(2 * math.pi * 440 * i / sample_rate))
+        frames.extend(struct.pack("<h", amp))
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(bytes(frames))
+    return path
+
+
+class TestPluginContract:
+    def test_modality(self, plugin: AudioTTSPlugin) -> None:
+        assert plugin.modality == Modality.AUDIO_TTS
+
+    def test_output_media_is_mp3(self, plugin: AudioTTSPlugin) -> None:
+        assert plugin.output_media == ["audio/mpeg"]
+
+
+class TestValidateSlotValues:
+    @pytest.mark.asyncio
+    async def test_simple_text_and_random_seed(
+        self, plugin: AudioTTSPlugin, simple_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            simple_manifest, {"text": "hello", "seed": "random"}
+        )
+        assert out["text"] == "hello"
+        assert isinstance(out["seed"], int)
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_text(
+        self, plugin: AudioTTSPlugin, simple_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(simple_manifest, {"text": ""})
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_slot(
+        self, plugin: AudioTTSPlugin, simple_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                simple_manifest, {"text": "x", "nonsense": 1}
+            )
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_accepts_path_string(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            voiceclone_manifest,
+            {"text": "hi", "voice_reference": "ref.wav"},
+        )
+        assert out["voice_reference"] == "ref.wav"
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_accepts_pathlib(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "ref.wav"
+        p.write_bytes(b"x")
+        out = await plugin.validate_slot_values(
+            voiceclone_manifest,
+            {"text": "hi", "voice_reference": p},
+        )
+        assert out["voice_reference"] == str(p)
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_accepts_attachment_dict(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            voiceclone_manifest,
+            {
+                "text": "hi",
+                "voice_reference": {
+                    "filename": "user.wav",
+                    "mime": "audio/wav",
+                    "data": b"riffwavedata",
+                },
+            },
+        )
+        ref = out["voice_reference"]
+        assert ref["filename"] == "user.wav"
+        assert ref["mime"] == "audio/wav"
+        assert ref["data"] == b"riffwavedata"
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_rejects_bad_dict_keys(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                voiceclone_manifest,
+                {
+                    "text": "hi",
+                    "voice_reference": {
+                        "filename": "user.wav",
+                        "data": b"x",
+                        "extra": "nope",
+                    },
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_rejects_unaccepted_mime(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                voiceclone_manifest,
+                {
+                    "text": "hi",
+                    "voice_reference": {
+                        "filename": "user.flac",
+                        "mime": "audio/flac",
+                        "data": b"x",
+                    },
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_accepts_listed_mime(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            voiceclone_manifest,
+            {
+                "text": "hi",
+                "voice_reference": {
+                    "filename": "user.wav",
+                    "mime": "audio/wav",
+                    "data": b"x",
+                },
+            },
+        )
+        assert out["voice_reference"]["mime"] == "audio/wav"
+
+    @pytest.mark.asyncio
+    async def test_audio_slot_rejects_wrong_type(
+        self, plugin: AudioTTSPlugin, voiceclone_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                voiceclone_manifest,
+                {"text": "hi", "voice_reference": 12345},
+            )
+
+
+class TestProgressMapper:
+    def test_reconnected_yields_none(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        assert mapper.update(Reconnected()) is None
+
+    def test_first_executing_reports_5(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        assert mapper.update(Executing(node="1", prompt_id="p")) == 5
+
+    def test_progress_scales_into_band(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Executing(node="1", prompt_id="p"))
+        v = mapper.update(Progress(node="1", value=5, max=10))
+        assert v is not None and 5 <= v <= 95
+
+    def test_monotone_across_progress(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        seen = []
+        mapper.update(Executing(node="1", prompt_id="p"))
+        for v in range(1, 11):
+            r = mapper.update(Progress(node="1", value=v, max=10))
+            if r is not None:
+                seen.append(r)
+        assert seen == sorted(seen)
+        assert seen[-1] <= 95
+
+    def test_execution_complete_pins_100(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Executing(node="1", prompt_id="p"))
+        mapper.update(Progress(node="1", value=2, max=10))
+        assert mapper.update(ExecutionComplete(prompt_id="p")) == 100
+
+    def test_executing_null_node_pins_100(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Executing(node="1", prompt_id="p"))
+        assert mapper.update(Executing(node=None, prompt_id="p")) == 100
+
+    def test_repeat_pct_returns_none(self, plugin: AudioTTSPlugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Executing(node="1", prompt_id="p"))
+        assert mapper.update(Executing(node="1", prompt_id="p")) is None
+
+
+class TestRenderOutputs:
+    @pytest.mark.asyncio
+    async def test_builds_payload_with_mp3_and_duration(
+        self,
+        plugin: AudioTTSPlugin,
+        simple_manifest,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        out_path = _write_tiny_wav(tmp_path / "tts_00001_.wav")
+        run = Run(
+            id=uuid.uuid4().hex,
+            manifest_id=simple_manifest.id,
+            prompt_id="prompt-id-xyz",
+            slot_values={"text": "Hello world", "seed": 42},
+            status=RunStatus.COMPLETE,
+        )
+        output = Output(
+            role=Role.OUTPUT_AUDIO,
+            media="audio/mpeg",
+            path=out_path,
+            bytes_read=out_path.read_bytes(),
+        )
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        payload = await plugin.render_outputs(run, [output])
+
+        assert payload.embed["title"] == simple_manifest.id
+        field_names = [f["name"] for f in payload.embed["fields"]]
+        assert "Text" in field_names
+        assert "Duration" in field_names
+        assert "Seed" in field_names
+
+        attached_names = [f.filename for f in payload.files]
+        assert out_path.name in attached_names
+
+    @pytest.mark.asyncio
+    async def test_oversize_skips_attachment_with_note(
+        self,
+        plugin: AudioTTSPlugin,
+        simple_manifest,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from core.modalities import audio_common as ac
+
+        oversize_bytes = b"\x00" * (ac.DISCORD_AUDIO_SIZE_LIMIT_BYTES + 16)
+        out_path = tmp_path / "huge.mp3"
+        out_path.write_bytes(oversize_bytes)
+
+        run = Run(
+            id="r",
+            manifest_id=simple_manifest.id,
+            slot_values={"text": "x"},
+        )
+        output = Output(
+            role=Role.OUTPUT_AUDIO,
+            media="audio/mpeg",
+            path=out_path,
+            bytes_read=oversize_bytes,
+        )
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        payload = await plugin.render_outputs(run, [output])
+
+        assert payload.files == []
+        assert "over Discord" in (payload.embed.get("description") or "")
+
+    @pytest.mark.asyncio
+    async def test_voice_reference_appears_in_embed(
+        self,
+        plugin: AudioTTSPlugin,
+        voiceclone_manifest,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        out_path = _write_tiny_wav(tmp_path / "out.wav")
+        run = Run(
+            id="r",
+            manifest_id=voiceclone_manifest.id,
+            slot_values={
+                "text": "voice clone",
+                "voice_reference": "ref-uploaded.wav",
+            },
+        )
+        output = Output(
+            role=Role.OUTPUT_AUDIO,
+            media="audio/mpeg",
+            path=out_path,
+            bytes_read=out_path.read_bytes(),
+        )
+        monkeypatch.setattr(audio_common, "_find_ffmpeg", lambda: None)
+        payload = await plugin.render_outputs(run, [output])
+        names = [f["name"] for f in payload.embed["fields"]]
+        assert "Voice reference" in names
+
+    @pytest.mark.asyncio
+    async def test_no_outputs_yields_no_files(
+        self, plugin: AudioTTSPlugin, simple_manifest
+    ) -> None:
+        run = Run(id="r", manifest_id=simple_manifest.id)
+        payload = await plugin.render_outputs(run, [])
+        assert payload.files == []
+
+
+class TestDefaultPostActions:
+    def test_returns_manifest_actions_verbatim(
+        self, plugin: AudioTTSPlugin, simple_manifest
+    ) -> None:
+        assert plugin.default_post_actions(simple_manifest) == list(
+            simple_manifest.actions
+        )

--- a/workflows/audio_tts_fish_simple.json
+++ b/workflows/audio_tts_fish_simple.json
@@ -1,0 +1,39 @@
+{
+  "1": {
+    "inputs": {
+      "model_path": "s2-pro",
+      "text": "Hello! [excited] This is Fish Audio S2.",
+      "language": "auto",
+      "device": "auto",
+      "precision": "auto",
+      "attention": "auto",
+      "max_new_tokens": 0,
+      "chunk_length": 200,
+      "temperature": 0.8,
+      "top_p": 0.8,
+      "repetition_penalty": 1.1,
+      "seed": 0,
+      "keep_model_loaded": true,
+      "offload_to_cpu": false,
+      "compile_model": false
+    },
+    "class_type": "FishS2TTS",
+    "_meta": {
+      "title": "Fish Audio S2 TTS"
+    }
+  },
+  "2": {
+    "inputs": {
+      "audio": [
+        "1",
+        0
+      ],
+      "filename_prefix": "discomfy/audio_tts_fish_simple",
+      "quality": "V0"
+    },
+    "class_type": "SaveAudioMP3",
+    "_meta": {
+      "title": "Save Audio (MP3)"
+    }
+  }
+}

--- a/workflows/audio_tts_fish_voiceclone.json
+++ b/workflows/audio_tts_fish_voiceclone.json
@@ -1,0 +1,53 @@
+{
+  "10": {
+    "inputs": {
+      "audio": "ref.wav"
+    },
+    "class_type": "LoadAudio",
+    "_meta": {
+      "title": "Load Reference Audio"
+    }
+  },
+  "1": {
+    "inputs": {
+      "model_path": "s2-pro",
+      "text": "Hello! [excited] This is my cloned voice.",
+      "reference_audio": [
+        "10",
+        0
+      ],
+      "language": "auto",
+      "device": "auto",
+      "precision": "auto",
+      "attention": "auto",
+      "max_new_tokens": 0,
+      "chunk_length": 200,
+      "temperature": 0.8,
+      "top_p": 0.8,
+      "repetition_penalty": 1.1,
+      "seed": 0,
+      "keep_model_loaded": true,
+      "offload_to_cpu": false,
+      "compile_model": false,
+      "reference_text": ""
+    },
+    "class_type": "FishS2VoiceCloneTTS",
+    "_meta": {
+      "title": "Fish Audio S2 Voice Clone TTS"
+    }
+  },
+  "2": {
+    "inputs": {
+      "audio": [
+        "1",
+        0
+      ],
+      "filename_prefix": "discomfy/audio_tts_fish_voiceclone",
+      "quality": "V0"
+    },
+    "class_type": "SaveAudioMP3",
+    "_meta": {
+      "title": "Save Audio (MP3)"
+    }
+  }
+}

--- a/workflows/manifests/audio_tts_fish_simple.yaml
+++ b/workflows/manifests/audio_tts_fish_simple.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+id: audio_tts_fish_simple
+name: "Fish-Speech S2 (TTS)"
+description: |
+  Single-pass text-to-speech via the Fish-Speech S2-Pro built-in voice.
+  Drop a sentence in, get an MP3 back. Use [excited], [whisper], [pause]
+  and similar inline tags inside the text for emotion control. ADR-0007
+  is the audio Modality anchor; this is the tracer-bullet manifest for
+  the audio_tts Plugin (Slice 7 / issue #9).
+modality: audio_tts
+workflow_file: workflows/audio_tts_fish_simple.json
+
+requires:
+  packs:
+    - custom_nodes.ComfyUI-FishAudioS2
+
+slots:
+  - name: text
+    type: text
+    role: prompt_positive
+    target: { node: "1", field: "text" }
+    ui:
+      hint: long_text
+      label: "Text"
+      placeholder: "Hello! [excited] This is Fish-Speech."
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "1", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+outputs:
+  - role: output_audio
+    node: "2"
+    media: audio/mpeg
+
+actions: []

--- a/workflows/manifests/audio_tts_fish_voiceclone.yaml
+++ b/workflows/manifests/audio_tts_fish_voiceclone.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+id: audio_tts_fish_voiceclone
+name: "Fish-Speech S2 Voice Clone (TTS)"
+description: |
+  Voice-cloning text-to-speech via Fish-Speech S2-Pro. Attach a 5-30s
+  reference clip (WAV / MP3); the model speaks the supplied text in
+  that voice. Reference audio uploads use ComfyUI's /upload/image
+  endpoint per ADR-0007 (the v3 HTTP client's upload_audio alias).
+modality: audio_tts
+workflow_file: workflows/audio_tts_fish_voiceclone.json
+
+requires:
+  packs:
+    - custom_nodes.ComfyUI-FishAudioS2
+
+slots:
+  - name: text
+    type: text
+    role: prompt_positive
+    target: { node: "1", field: "text" }
+    ui:
+      hint: long_text
+      label: "Text"
+      placeholder: "Hello! [excited] This is my cloned voice."
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: voice_reference
+    type: audio
+    role: reference_audio
+    target: { node: "10", field: "audio" }
+    ui:
+      hint: audio
+      label: "Reference voice clip"
+      placeholder: "5-30s of clean speech is best"
+      required: true
+      attachment_position: 1
+    validation:
+      accepts:
+        - audio/wav
+        - audio/mpeg
+        - audio/x-wav
+        - audio/mp3
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "1", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+outputs:
+  - role: output_audio
+    node: "2"
+    media: audio/mpeg
+
+actions: []


### PR DESCRIPTION
Closes #9.

First audio slice. Introduces the `audio_tts` Modality Plugin plus a
shared `audio_common` helper module that **Slice 8 (ACE-Step music)
will reuse** - the helpers are deliberately Plugin-agnostic (no
Fish-Speech assumptions baked in).

## Deliverables

- `core/modalities/audio_common.py` (NEW, **shared with Slice 8**) -
  Discord MP3 packaging, duration probing (ffprobe ➜ ffmpeg-stderr
  ➜ `wave` stdlib fallback), waveform PNG rendering, WAV➜MP3
  transcoding. All ffmpeg / ffprobe subprocess calls are fail-soft.
- `core/modalities/audio_tts/{__init__.py,plugin.py}` (NEW) -
  `AudioTTSPlugin` implementing `ModalityPlugin` with single-pass
  monotone progress mapper, AUDIO-slot coercion (path / `pathlib.Path`
  / `{filename, mime, data}` dict), `validation.accepts` MIME gating,
  and a renderer that posts MP3 + duration label + waveform preview.
- `workflows/audio_tts_fish_simple.{json,yaml}` (NEW) - tracer-bullet
  manifest: `FishS2TTS` ➜ `SaveAudioMP3`. Pack:
  `custom_nodes.ComfyUI-FishAudioS2`.
- `workflows/audio_tts_fish_voiceclone.{json,yaml}` (NEW) - voice-clone
  manifest: `LoadAudio` ➜ `FishS2VoiceCloneTTS` ➜ `SaveAudioMP3` with
  a required AUDIO Slot at `attachment_position: 1` and
  `validation.accepts` filtered to `audio/wav` / `audio/mpeg` etc.
- `scripts/v3_smoke.py` (MODIFIED) - AUDIO Slots whose value is a
  local path are uploaded via `http.upload_audio` (alias of
  `/upload/image` with audio mimes per ADR-0007) before queueing; the
  assigned filename replaces the override. Already-uploaded names
  pass through unchanged.
- `core/modalities/{__init__.py,registry.py}` (MODIFIED) - register
  `AudioTTSPlugin` for `Modality.AUDIO_TTS`.
- `tests/test_audio_common.py`, `tests/test_audio_tts_plugin.py`,
  `tests/test_audio_manifest_loading.py` (NEW) - 52 new unit tests.

## Acceptance criteria

- [x] `audio_common.package_for_discord` returns a Discord-ready
      bundle (filename + bytes + duration + waveform + oversize flag).
- [x] `extract_duration_seconds` works without ffprobe via the
      `wave` stdlib fallback for WAV inputs; logs + returns `-1.0`
      when every probe fails.
- [x] `transcode_to_mp3` shells out to ffmpeg (system or
      `imageio_ffmpeg`-bundled) and raises `AudioToolingMissing`
      when no binary is available.
- [x] `AudioTTSPlugin` validator coerces TEXT / SEED slots, accepts
      `str | Path | {filename, mime, data}` for AUDIO slots, and
      enforces `validation.accepts` MIME filters.
- [x] Progress mapper reports monotone 0..100 across `Reconnected`,
      first-`Executing`, `Progress`, `ExecutionComplete`, and
      `Executing(node=None)` events.
- [x] Renderer posts the MP3 + duration label + waveform PNG (or a
      stub when oversize / no ffmpeg) and includes the voice
      reference filename in the embed when present.
- [x] Both manifests load via `core.manifest.load_manifest` and
      route to `AudioTTSPlugin` through `default_registry`.
- [x] `scripts/v3_smoke.py --slot voice_reference=/path/to/ref.wav`
      uploads via `upload_audio` and feeds the assigned filename
      into the workflow.
- [x] No `model_type` / `DyPE` / `hidream` / `krea` strings added.
- [x] Existing v3.0 baseline tests still pass (247 passed locally,
      including the 52 new audio tests).
- [ ] **Live smoke deferred** - see below.

## Live smoke evidence

**TODO_SMOKE.** ComfyUI at `http://172.27.1.165:8188` was unreachable
from the agent worktree during the slice (TCP probe timed out).
Per `AGENTS.md` "If ComfyUI unreachable: defer per the standard rule."

Reproduction commands and a results table are checked in at
`docs/v3/smoke/SLICE_9_RUNS.md`. The maintainer (or a follow-up
agent on a network with access) should fill in `prompt_id`, output
paths, byte counts, durations, and latencies for both the simple
and the voice-clone runs before merging.

Quick repro once ComfyUI is reachable:

```bash
source venv/bin/activate
python scripts/v3_smoke.py --manifest audio_tts_fish_simple \
  --slot text="Hello world, this is a Fish-Speech tracer-bullet smoke."
ffmpeg -y -f lavfi -i sine=frequency=440:duration=5 /tmp/ref.wav
python scripts/v3_smoke.py --manifest audio_tts_fish_voiceclone \
  --slot text="Voice-cloning tracer bullet via Fish-Speech S2." \
  --slot voice_reference=/tmp/ref.wav
```

## Test plan

- [x] `pytest -q tests/test_audio_common.py tests/test_audio_tts_plugin.py tests/test_audio_manifest_loading.py` ➜ 52 passed
- [x] Full pre-existing v3.0 baseline + new audio tests (24 files) ➜ 247 passed
- [x] Offline `apply_slots` + plugin validation dry-run for both manifests
- [ ] Live ComfyUI smoke: simple ➜ deferred (ComfyUI unreachable)
- [ ] Live ComfyUI smoke: voice-clone ➜ deferred (ComfyUI unreachable)

## Audio handling decisions

- **MP3 only on the wire to Discord.** Both manifests terminate at
  `SaveAudioMP3` so no transcode is required for the TTS slice.
  `audio_common.transcode_to_mp3` is shipped anyway because Slice 8
  (ACE-Step music) and any future plain-`SaveAudio` workflow will
  need it.
- **Waveform via ffmpeg + PIL.** ffmpeg pipes mono int16 PCM to
  `audio_common._draw_waveform_png`, which bins samples into
  `width=600` columns and draws a 100px monochrome silhouette. Output
  is ~5-10 KB - cheap to attach.
- **ffmpeg fallback.** `audio_common._find_ffmpeg` checks `$PATH`
  first, then `imageio_ffmpeg.get_ffmpeg_exe()` (already a transitive
  dep). Hosts without ffmpeg get `Duration: unknown` and no waveform
  attachment but the MP3 is still posted.
- **Discord 25 MB cap.** `package_for_discord` flips an `oversize`
  flag at 25 MB; the renderer omits the file attachment and adds a
  description line so the user knows where the file landed on disk.
- **Pack name from `/object_info`.** `custom_nodes.ComfyUI-FishAudioS2`
  was read from the live discovery raw probe (`docs/v3/discovery.raw.json`
  ➜ `FishS2TTS.python_module`); not guessed.

## Anchors

- PRD: `docs/v3/PRD.md` user stories 9, 10 (TTS + voice clone).
- ADR-0001: `REFERENCE_AUDIO` Role and `AUDIO` SlotType (already in
  `core/manifest/roles.py` / `schema.py`; this slice exercises them).
- ADR-0002: ModalityPlugin Protocol; `AudioTTSPlugin` is the second
  Plugin to implement it (after `ImageT2IPlugin`).
- ADR-0004: `core/comfyui/v3/http.py.upload_audio` is what
  `scripts/v3_smoke.py` calls for reference-audio uploads.
- ADR-0007: Fish-Speech as the TTS pick (F5-TTS is **not** installed);
  `audio_common` is the shared helper module that ADR-0007 calls out.

Made with [Cursor](https://cursor.com)