### PR TITLE
Slice 5: video Modality + WAN 2.2 i2v with HIGH+LOW UNET pair (#7)

### DIFF
--- a/core/modalities/registry.py
+++ b/core/modalities/registry.py
@@ -56,9 +56,11 @@ def _wire_default_plugins() -> None:
     """
     from core.modalities.image_t2i.plugin import ImageT2IPlugin
     from core.modalities.image_upscale.plugin import ImageUpscalePlugin
+    from core.modalities.video.plugin import VideoPlugin
 
     default_registry.register(ImageT2IPlugin())
     default_registry.register(ImageUpscalePlugin())
+    default_registry.register(VideoPlugin())
 
 
 _wire_default_plugins()

--- a/core/modalities/video/__init__.py
+++ b/core/modalities/video/__init__.py
@@ -1,0 +1,10 @@
+"""Video Modality Plugin package (ADR-0002).
+
+Exposes :class:`VideoPlugin`; the Modality Registry wires it up.
+"""
+
+from __future__ import annotations
+
+from core.modalities.video.plugin import VideoPlugin
+
+__all__ = ["VideoPlugin"]

--- a/core/modalities/video/plugin.py
+++ b/core/modalities/video/plugin.py
@@ -1,0 +1,269 @@
+"""Video Plugin (ADR-0002).
+
+Modality contract:
+
+- ``output_media``: ``["video/mp4"]``
+- Validator: shared coerce + validation helpers from :mod:`core.modalities.base`.
+  Image-type Slots (``init_image``) pass through as opaque values; the bot
+  uploads the attachment to ComfyUI and writes the resulting filename into
+  the Slot value before :func:`core.manifest.apply_slots` is called.
+- ProgressMapper: two-phase, designed for the multi-UNET dual-KSampler
+  pattern (HIGH-noise pass + LOW-noise pass) of WAN 2.2 i2v. The two
+  KSampler nodes each emit their own ``Progress`` stream; we sum them
+  into a single percentage that occupies 0-95% of the bar. The remaining
+  5% is reserved for post-sampling nodes (VAE decode, VHS_VideoCombine
+  assembly) which fire ``Executing`` events but no ``Progress`` events.
+- Renderer: posts the MP4 file as a Discord attachment with an embed
+  carrying prompt, frame count, duration (assuming 16 fps default - the
+  VHS default and the Wan 2.2 native frame rate), and file size. If the
+  file exceeds 25 MB (Discord's per-message cap for non-Nitro bots) the
+  Plugin returns a content message naming the ComfyUI-side filename and
+  omits the attachment; external upload is a v3.x deliverable.
+- Default actions: respect the Manifest's declared Actions verbatim.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.manifest.roles import Modality, Role
+from core.manifest.schema import Action, Manifest
+from core.modalities.base import (
+    ProgressMapper,
+    SlotValueValidationError,
+    SlotValues,
+    coerce_slot_values_against_manifest,
+    enforce_validation_rules,
+)
+from core.run import DiscordFile, DiscordPayload, Output, Run
+
+DEFAULT_VIDEO_FPS: int = 16
+DISCORD_FILE_CAP_BYTES: int = 25 * 1024 * 1024
+SAMPLING_CEILING: int = 95
+POST_SAMPLE_BUMP: int = 2
+POST_SAMPLE_CEILING: int = 99
+
+
+class _DualSamplerProgressMapper:
+    """Sum dual-sampler progress + bump on post-sampling Executing events.
+
+    The WAN 2.2 i2v pipeline runs two ``KSampler`` nodes in sequence:
+    the HIGH-noise UNET on the early timesteps, then the LOW-noise UNET
+    on the refinement timesteps. Each KSampler emits its own ``progress``
+    stream. We accumulate per-node ``(value, max)`` into a global ratio
+    and scale to 0-95% so post-sampling work has somewhere to go.
+
+    Post-sampling nodes (``VAEDecode``, ``VHS_VideoCombine``) emit
+    ``executing`` events but no ``progress`` events; we bump 2% per
+    ``Executing`` of a node we've never seen progress for (capped at 99%)
+    until ``ExecutionComplete`` or ``Executing(node=None)`` flips the bar
+    to 100%.
+    """
+
+    def __init__(self) -> None:
+        self._per_node: dict[str, tuple[int, int]] = {}
+        self._post_sample_bumps: int = 0
+        self._sampling_seen: bool = False
+        self._last_pct: int | None = None
+        self._complete: bool = False
+
+    def update(self, event: Any) -> int | None:
+        from core.comfyui.v3.ws import (
+            Executing,
+            ExecutionComplete,
+            Progress,
+            Reconnected,
+        )
+
+        if isinstance(event, Reconnected):
+            return self._last_pct
+        if isinstance(event, ExecutionComplete):
+            return self._mark_complete()
+        if isinstance(event, Executing) and event.node is None and event.prompt_id:
+            return self._mark_complete()
+        if isinstance(event, Progress):
+            self._sampling_seen = True
+            node = event.node or "_default_"
+            max_steps = max(int(event.max), 1)
+            value = max(0, min(int(event.value), max_steps))
+            self._per_node[node] = (value, max_steps)
+            total_value = sum(v for v, _ in self._per_node.values())
+            total_max = sum(m for _, m in self._per_node.values())
+            if total_max <= 0:
+                return None
+            pct = int((total_value / total_max) * SAMPLING_CEILING)
+            return self._monotone(pct)
+        if isinstance(event, Executing) and event.node is not None:
+            if self._sampling_seen and event.node not in self._per_node:
+                self._post_sample_bumps += 1
+                pct = min(
+                    SAMPLING_CEILING + POST_SAMPLE_BUMP * self._post_sample_bumps,
+                    POST_SAMPLE_CEILING,
+                )
+                return self._monotone(pct)
+        return None
+
+    def _mark_complete(self) -> int:
+        self._complete = True
+        self._last_pct = 100
+        return 100
+
+    def _monotone(self, pct: int) -> int | None:
+        if self._complete:
+            pct = 100
+        if self._last_pct is not None:
+            pct = max(pct, self._last_pct)
+        if pct == self._last_pct:
+            return None
+        self._last_pct = pct
+        return pct
+
+
+class VideoPlugin:
+    """Plugin for the ``video`` Modality. ADR-0002 contract."""
+
+    modality: Modality = Modality.VIDEO
+    output_media: list[str] = ["video/mp4"]
+
+    async def validate_slot_values(
+        self, manifest: Manifest, values: SlotValues
+    ) -> SlotValues:
+        coerced = coerce_slot_values_against_manifest(manifest, values)
+        enforce_validation_rules(manifest, coerced)
+        return coerced
+
+    def progress_mapper(self) -> ProgressMapper:
+        return _DualSamplerProgressMapper()
+
+    async def render_outputs(
+        self, run: Run, outputs: list[Output]
+    ) -> DiscordPayload:
+        videos = [o for o in outputs if o.role == Role.OUTPUT_VIDEO]
+        primary = videos[0] if videos else None
+
+        fields: list[dict[str, Any]] = []
+        prompt = run.slot_values.get("prompt")
+        if prompt:
+            fields.append(
+                {
+                    "name": "Prompt",
+                    "value": _truncate(str(prompt), 1024),
+                    "inline": False,
+                }
+            )
+        negative = run.slot_values.get("negative_prompt")
+        if negative:
+            fields.append(
+                {
+                    "name": "Negative",
+                    "value": _truncate(str(negative), 1024),
+                    "inline": False,
+                }
+            )
+        frame_count = run.slot_values.get("frame_count")
+        if frame_count is not None:
+            fields.append(
+                {
+                    "name": "Frames",
+                    "value": str(frame_count),
+                    "inline": True,
+                }
+            )
+            duration = _format_duration(int(frame_count), DEFAULT_VIDEO_FPS)
+            fields.append(
+                {
+                    "name": "Duration",
+                    "value": duration,
+                    "inline": True,
+                }
+            )
+        width = run.slot_values.get("width")
+        height = run.slot_values.get("height")
+        if width and height:
+            fields.append(
+                {"name": "Size", "value": f"{width}x{height}", "inline": True}
+            )
+        seed = run.slot_values.get("seed")
+        if seed is not None:
+            fields.append({"name": "Seed", "value": str(seed), "inline": True})
+
+        if primary is not None:
+            fields.append(
+                {
+                    "name": "File size",
+                    "value": _format_bytes(primary.size_bytes),
+                    "inline": True,
+                }
+            )
+
+        embed: dict[str, Any] = {
+            "title": run.manifest_id,
+            "color": 0x5865F2,
+            "fields": fields,
+            "footer": {
+                "text": f"prompt_id: {run.prompt_id}" if run.prompt_id else ""
+            },
+        }
+
+        files: list[DiscordFile] = []
+        content: str | None = None
+
+        if primary is None:
+            embed["description"] = "No video output."
+            return DiscordPayload(embed=embed, files=files)
+
+        if primary.size_bytes > DISCORD_FILE_CAP_BYTES:
+            content = (
+                f"\u26a0\ufe0f Video `{primary.filename}` is "
+                f"{_format_bytes(primary.size_bytes)}, over Discord's "
+                f"{_format_bytes(DISCORD_FILE_CAP_BYTES)} attachment cap. "
+                "Fetch it from ComfyUI's `/view?filename="
+                f"{primary.filename}&type=output` endpoint. External upload "
+                "lands in v3.x."
+            )
+            embed.setdefault("description", "")
+            embed["description"] = (embed["description"] + "\n" if embed["description"] else "") + (
+                f"File too large for Discord attachment ({_format_bytes(primary.size_bytes)})."
+            )
+        else:
+            files.append(
+                DiscordFile(
+                    filename=primary.filename,
+                    content_type=primary.media,
+                    data=primary.bytes_read,
+                )
+            )
+
+        return DiscordPayload(embed=embed, files=files, content=content)
+
+    def default_post_actions(self, manifest: Manifest) -> list[Action]:
+        return list(manifest.actions)
+
+
+def _truncate(s: str, limit: int) -> str:
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "\u2026"
+
+
+def _format_bytes(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+def _format_duration(frame_count: int, fps: int) -> str:
+    if fps <= 0:
+        return f"{frame_count} frames"
+    seconds = frame_count / fps
+    if seconds < 60:
+        return f"{seconds:.1f}s @ {fps}fps"
+    minutes, secs = divmod(seconds, 60)
+    return f"{int(minutes)}m{secs:04.1f}s @ {fps}fps"
+
+
+__all__ = ["DISCORD_FILE_CAP_BYTES", "DEFAULT_VIDEO_FPS", "VideoPlugin"]

--- a/scripts/v3_smoke.py
+++ b/scripts/v3_smoke.py
@@ -6,14 +6,24 @@ Usage::
         --manifest qwen_image_2512 \
         --slot prompt="a single red panda eating bamboo"
 
+    # i2v with an attachment - the harness uploads the file and writes the
+    # ComfyUI-side filename into the slot value before applying:
+    python scripts/v3_smoke.py \
+        --manifest wan22_i2v \
+        --slot prompt="camera pans right" \
+        --slot init_image=output/v3_smoke/abc/img.png \
+        --slot frame_count=17
+
 Loads the manifest registry from ``workflows/manifests/``, validates the
-named manifest's ``requires`` against the live ``/object_info``, applies
-user-supplied slot overrides via the v3 ``apply_slots``, queues the
-workflow with the v3 ``ComfyHTTPClient``, follows progress with the v3
-``WSClient`` until ``ExecutionComplete``, downloads every Output the
-manifest declares via the Plugin's renderer, saves them to
-``output/v3_smoke/<prompt_id>/`` and reports prompt id, output paths,
-sizes, and wall-clock latency.
+named manifest's ``requires`` against the live ``/object_info``, uploads
+any IMAGE slot whose value is a local file path (via ``/upload/image``)
+and rewrites the value to the server-side filename, applies user-supplied
+slot overrides via the v3 ``apply_slots``, queues the workflow with the
+v3 ``ComfyHTTPClient``, follows progress with the v3 ``WSClient`` until
+``ExecutionComplete``, downloads every Output the manifest declares
+(images, videos via ``VHS_VideoCombine``'s legacy ``gifs`` bucket, or
+audio), saves them to ``output/v3_smoke/<prompt_id>/`` and reports prompt
+id, output paths, sizes, and wall-clock latency.
 
 This script is the validation gate for every v3 slice. It runs without
 Discord, exits 0 on success, non-zero on failure with a clear message.
@@ -409,11 +419,23 @@ async def _collect_outputs(
                 f"manifest '{manifest.id}' declares output on node '{spec.node}' "
                 f"but history has no outputs for that node (got: {sorted(node_outputs)})"
             )
-        bucket = _bucket_for_media(spec.media)
-        files = node_data.get(bucket, []) or []
+        buckets = _candidate_buckets_for_media(spec.media)
+        files: list[dict[str, Any]] = []
+        for bucket in buckets:
+            entries = node_data.get(bucket, []) or []
+            if entries:
+                files = entries
+                logger.info(
+                    "found %d %s entries on node '%s'",
+                    len(entries),
+                    bucket,
+                    spec.node,
+                )
+                break
         if not files:
             raise SmokeError(
-                f"node '{spec.node}' produced no {bucket} for prompt {run.prompt_id}"
+                f"node '{spec.node}' produced no {'/'.join(buckets)} for prompt "
+                f"{run.prompt_id}; node_data keys={sorted(node_data)}"
             )
         for f in files:
             filename = f.get("filename")
@@ -443,15 +465,23 @@ async def _collect_outputs(
     return collected
 
 
-def _bucket_for_media(media: str) -> str:
-    """Map a manifest MIME to the key ComfyUI history uses."""
+def _candidate_buckets_for_media(media: str) -> list[str]:
+    """Map a manifest MIME to ComfyUI history bucket keys, in priority order.
+
+    Different ComfyUI nodes use different keys for the same output kind:
+    SaveImage uses ``images``; the legacy VHS_VideoCombine custom node
+    emits MP4 / WebM under ``gifs`` (historical naming) and newer builds
+    may also expose ``videos``. We try all plausible names per Modality
+    so the smoke harness does not need to know which node authored the
+    output.
+    """
     if media.startswith("image/"):
-        return "images"
+        return ["images"]
     if media.startswith("video/"):
-        return "videos"
+        return ["videos", "gifs", "files"]
     if media.startswith("audio/"):
-        return "audio"
-    return "files"
+        return ["audio", "files"]
+    return ["files"]
 
 
 def _redact_for_log(values: dict[str, Any]) -> dict[str, Any]:

--- a/tests/fixtures/object_info_slim.json
+++ b/tests/fixtures/object_info_slim.json
@@ -934,6 +934,60 @@
       "scale latent"
     ]
   },
+  "VHS_VideoCombine": {
+    "input": {
+      "required": {
+        "images": ["IMAGE"],
+        "frame_rate": ["FLOAT", {"default": 8, "min": 1, "step": 1}],
+        "loop_count": ["INT", {"default": 0, "min": 0, "max": 100, "step": 1}],
+        "filename_prefix": ["STRING", {"default": "AnimateDiff"}],
+        "format": [["video/h264-mp4", "video/h265-mp4", "video/webm"]],
+        "pingpong": ["BOOLEAN", {"default": false}],
+        "save_output": ["BOOLEAN", {"default": true}]
+      }
+    },
+    "is_input_list": false,
+    "output": ["VHS_FILENAMES"],
+    "output_is_list": [false],
+    "output_name": ["Filenames"],
+    "name": "VHS_VideoCombine",
+    "display_name": "Video Combine",
+    "description": "Combine images into a video.",
+    "python_module": "custom_nodes.comfyui-videohelpersuite",
+    "category": "Video Helper Suite",
+    "output_node": true,
+    "has_intermediate_output": false,
+    "search_aliases": []
+  },
+  "WanImageToVideo": {
+    "input": {
+      "required": {
+        "positive": ["CONDITIONING"],
+        "negative": ["CONDITIONING"],
+        "vae": ["VAE"],
+        "width": ["INT", {"default": 832, "min": 16, "max": 16384, "step": 16}],
+        "height": ["INT", {"default": 480, "min": 16, "max": 16384, "step": 16}],
+        "length": ["INT", {"default": 81, "min": 1, "max": 16384, "step": 4}],
+        "batch_size": ["INT", {"default": 1, "min": 1, "max": 4096}]
+      },
+      "optional": {
+        "clip_vision_output": ["CLIP_VISION_OUTPUT"],
+        "start_image": ["IMAGE"]
+      }
+    },
+    "is_input_list": false,
+    "output": ["CONDITIONING", "CONDITIONING", "LATENT"],
+    "output_is_list": [false, false, false],
+    "output_name": ["positive", "negative", "latent"],
+    "name": "WanImageToVideo",
+    "display_name": "Wan Image To Video",
+    "description": "Builds the i2v latent for WAN 2.x.",
+    "python_module": "comfy_extras.nodes_wan",
+    "category": "conditioning/video_models",
+    "output_node": false,
+    "has_intermediate_output": false,
+    "search_aliases": []
+  },
   "ModelSamplingAuraFlow": {
     "input": {
       "required": {

--- a/tests/test_multi_unet_pattern.py
+++ b/tests/test_multi_unet_pattern.py
@@ -1,0 +1,169 @@
+"""Architectural test: the multi-UNET Manifest pattern (ADR-0001).
+
+This is the golden test for the WAN 2.2 HIGH+LOW dual-UNET workflow.
+Applying ``model_high`` and ``model_low`` Slot values must write into
+TWO distinct ``UNETLoader`` nodes (different node IDs) - not collide
+into the same node, not silently drop one of the two.
+
+The seed slot, which uses ``targets: [...]``, exercises the same
+multi-target mechanism for a single value landing on two nodes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.manifest import apply_slots, load_manifest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return load_manifest(REPO_ROOT / "workflows" / "manifests" / "wan22_i2v.yaml")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return json.loads(
+        (REPO_ROOT / "workflows" / "wan22_i2v.json").read_text(encoding="utf-8")
+    )
+
+
+def _high_low_unet_nodes(workflow: dict) -> tuple[str, str]:
+    """Find the two UNETLoader nodes and label them HIGH/LOW by the file."""
+    by_unet: dict[str, str] = {}
+    for node_id, node in workflow.items():
+        if node.get("class_type") == "UNETLoader":
+            by_unet[node["inputs"]["unet_name"]] = node_id
+    return (
+        next(nid for name, nid in by_unet.items() if "FP8H" in name),
+        next(nid for name, nid in by_unet.items() if "FP8L" in name),
+    )
+
+
+class TestMultiUnetMapping:
+    def test_workflow_declares_two_distinct_unet_nodes(self, workflow) -> None:
+        unet_nodes = [
+            nid
+            for nid, n in workflow.items()
+            if n.get("class_type") == "UNETLoader"
+        ]
+        assert len(unet_nodes) == 2
+        assert unet_nodes[0] != unet_nodes[1]
+
+    def test_manifest_targets_two_distinct_unet_nodes(self, manifest) -> None:
+        slots = manifest.slots_by_name()
+        high_targets = [t.node for t in slots["model_high"].resolved_targets()]
+        low_targets = [t.node for t in slots["model_low"].resolved_targets()]
+        assert len(high_targets) == 1
+        assert len(low_targets) == 1
+        assert high_targets[0] != low_targets[0]
+
+    def test_apply_slots_writes_both_unets(self, manifest, workflow) -> None:
+        high_node, low_node = _high_low_unet_nodes(workflow)
+        values = {
+            "prompt": "camera pans right across a misty forest",
+            "init_image": "src.png",
+            "model_high": (
+                "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors"
+            ),
+            "model_low": (
+                "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors"
+            ),
+            "frame_count": 17,
+            "seed": 12345,
+            "cfg": 6.0,
+            "steps_high": 4,
+            "steps_low": 4,
+        }
+        applied = apply_slots(workflow, manifest, values)
+        assert applied[high_node]["inputs"]["unet_name"].endswith("FP8H.safetensors")
+        assert applied[low_node]["inputs"]["unet_name"].endswith("FP8L.safetensors")
+        assert (
+            applied[high_node]["inputs"]["unet_name"]
+            != applied[low_node]["inputs"]["unet_name"]
+        )
+
+    def test_apply_slots_preserves_dual_lora_wiring(
+        self, manifest, workflow
+    ) -> None:
+        """Each LoraLoaderModelOnly must stay wired to its matching UNET."""
+        applied = apply_slots(
+            workflow,
+            manifest,
+            {
+                "prompt": "x",
+                "init_image": "src.png",
+                "model_high": (
+                    "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors"
+                ),
+                "model_low": (
+                    "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors"
+                ),
+            },
+        )
+        high_node, low_node = _high_low_unet_nodes(workflow)
+        loras = {
+            nid: n
+            for nid, n in applied.items()
+            if n.get("class_type") == "LoraLoaderModelOnly"
+        }
+        assert len(loras) == 2
+        upstream_unets = {nid: l["inputs"]["model"][0] for nid, l in loras.items()}
+        assert set(upstream_unets.values()) == {high_node, low_node}
+        for lora_id, lora in loras.items():
+            upstream = lora["inputs"]["model"][0]
+            if upstream == high_node:
+                assert "HIGH" in lora["inputs"]["lora_name"]
+            elif upstream == low_node:
+                assert "LOW" in lora["inputs"]["lora_name"]
+
+    def test_seed_value_lands_on_both_samplers(
+        self, manifest, workflow
+    ) -> None:
+        """Multi-target slot (seed) demonstrates the same mechanism."""
+        applied = apply_slots(
+            workflow,
+            manifest,
+            {
+                "prompt": "x",
+                "init_image": "src.png",
+                "seed": 987654321,
+            },
+        )
+        sampler_ids = [
+            nid
+            for nid, n in applied.items()
+            if n.get("class_type") == "KSampler"
+        ]
+        assert len(sampler_ids) == 2
+        for sid in sampler_ids:
+            assert applied[sid]["inputs"]["seed"] == 987654321
+
+    def test_steps_high_and_low_target_distinct_samplers(
+        self, manifest, workflow
+    ) -> None:
+        applied = apply_slots(
+            workflow,
+            manifest,
+            {
+                "prompt": "x",
+                "init_image": "src.png",
+                "steps_high": 7,
+                "steps_low": 3,
+            },
+        )
+        sampler_ids = sorted(
+            nid
+            for nid, n in applied.items()
+            if n.get("class_type") == "KSampler"
+        )
+        steps_seen = sorted(
+            applied[sid]["inputs"]["steps"] for sid in sampler_ids
+        )
+        assert steps_seen == [3, 7]

--- a/tests/test_video_plugin.py
+++ b/tests/test_video_plugin.py
@@ -1,0 +1,370 @@
+"""Tests for the video Plugin (ADR-0002).
+
+Three seams under test:
+
+- ``validate_slot_values`` coerces / validates raw user input against
+  the WAN 2.2 i2v manifest, accepting image-slot values as opaque
+  filename strings (the SmokeHarness uploads then writes them back).
+- The dual-sampler ProgressMapper sums HIGH-pass + LOW-pass KSampler
+  ``Progress`` events into a monotone 0-95% stream, bumps on
+  post-sampling ``Executing`` events (VAEDecode + VHS_VideoCombine),
+  and flips to 100% on ``ExecutionComplete``.
+- ``render_outputs`` produces a :class:`DiscordPayload` carrying an MP4
+  attachment plus an embed with prompt / frame count / duration / size,
+  and falls back to a content message (no attachment) for files over
+  the 25 MB Discord cap.
+
+No live ComfyUI; no Discord runtime.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.ws import (
+    Executing,
+    ExecutionComplete,
+    Progress,
+    Reconnected,
+)
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+from core.modalities.base import SlotValueValidationError
+from core.modalities.video.plugin import (
+    DISCORD_FILE_CAP_BYTES,
+    VideoPlugin,
+)
+from core.run import Output, Run, RunStatus
+
+
+@pytest.fixture
+def manifest():
+    return load_manifest("workflows/manifests/wan22_i2v.yaml")
+
+
+@pytest.fixture
+def plugin() -> VideoPlugin:
+    return VideoPlugin()
+
+
+class TestPluginContract:
+    def test_modality(self, plugin: VideoPlugin) -> None:
+        assert plugin.modality == Modality.VIDEO
+
+    def test_output_media_is_mp4(self, plugin: VideoPlugin) -> None:
+        assert plugin.output_media == ["video/mp4"]
+
+
+class TestValidateSlotValues:
+    @pytest.mark.asyncio
+    async def test_coerces_frame_count_string_to_int(
+        self, plugin, manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            manifest,
+            {
+                "prompt": "x",
+                "init_image": "frame.png",
+                "frame_count": "17",
+            },
+        )
+        assert isinstance(out["frame_count"], int)
+        assert out["frame_count"] == 17
+
+    @pytest.mark.asyncio
+    async def test_init_image_passes_through_filename(
+        self, plugin, manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            manifest,
+            {"prompt": "x", "init_image": "uploaded_frame.png"},
+        )
+        assert out["init_image"] == "uploaded_frame.png"
+
+    @pytest.mark.asyncio
+    async def test_init_image_accepts_dict_with_filename(
+        self, plugin, manifest
+    ) -> None:
+        attachment = {"filename": "uploaded_frame.png", "subfolder": ""}
+        out = await plugin.validate_slot_values(
+            manifest,
+            {"prompt": "x", "init_image": attachment},
+        )
+        assert out["init_image"] == attachment
+
+    @pytest.mark.asyncio
+    async def test_seed_random_becomes_int(self, plugin, manifest) -> None:
+        out = await plugin.validate_slot_values(
+            manifest,
+            {"prompt": "x", "init_image": "f.png", "seed": "random"},
+        )
+        assert isinstance(out["seed"], int)
+
+    @pytest.mark.asyncio
+    async def test_enforces_steps_high_max(self, plugin, manifest) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest,
+                {
+                    "prompt": "x",
+                    "init_image": "f.png",
+                    "steps_high": "99",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_steps_low_min(self, plugin, manifest) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest,
+                {
+                    "prompt": "x",
+                    "init_image": "f.png",
+                    "steps_low": "1",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_frame_count_bounds(self, plugin, manifest) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest,
+                {
+                    "prompt": "x",
+                    "init_image": "f.png",
+                    "frame_count": "500",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_cfg_bounds(self, plugin, manifest) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest,
+                {
+                    "prompt": "x",
+                    "init_image": "f.png",
+                    "cfg": "999.0",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_slot(self, plugin, manifest) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest,
+                {"prompt": "x", "init_image": "f.png", "not_a_slot": 1},
+            )
+
+
+class TestProgressMapper:
+    def test_reconnect_returns_last(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        assert mapper.update(Reconnected()) is None
+        mapper.update(Progress(node="11", value=2, max=4))
+        assert mapper.update(Reconnected()) is not None
+
+    def test_caps_sampling_at_95(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        first = mapper.update(Progress(node="11", value=4, max=4))
+        second = mapper.update(Progress(node="12", value=4, max=4))
+        # First call sees only node 11 at 4/4 -> 95%. Second call adds
+        # node 12 at 4/4 -> (4+4)/(4+4)*95 = 95%, which is the same as
+        # the last reported value so the mapper returns None.
+        assert first == 95
+        assert second is None
+
+    def test_monotone_across_two_samplers(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        out = []
+        for v in range(1, 5):
+            out.append(mapper.update(Progress(node="11", value=v, max=4)))
+        for v in range(1, 5):
+            out.append(mapper.update(Progress(node="12", value=v, max=4)))
+        filtered = [p for p in out if p is not None]
+        assert filtered == sorted(filtered), filtered
+        assert filtered[-1] == 95
+
+    def test_post_sample_executing_bumps_past_95(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="11", value=4, max=4))
+        mapper.update(Progress(node="12", value=4, max=4))
+        bump1 = mapper.update(Executing(node="13", prompt_id="x"))
+        bump2 = mapper.update(Executing(node="14", prompt_id="x"))
+        assert bump1 == 97
+        assert bump2 == 99
+
+    def test_post_sample_capped_at_99(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="11", value=4, max=4))
+        mapper.update(Progress(node="12", value=4, max=4))
+        last = None
+        for node_id in ["13", "14", "15", "16", "17"]:
+            last = mapper.update(Executing(node=node_id, prompt_id="x")) or last
+        assert last == 99
+
+    def test_executing_for_sampler_node_is_not_a_post_bump(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="11", value=4, max=4))
+        mapper.update(Progress(node="12", value=2, max=4))
+        result = mapper.update(Executing(node="12", prompt_id="x"))
+        assert result is None
+
+    def test_pre_sampling_executing_is_ignored(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        result = mapper.update(Executing(node="7", prompt_id="x"))
+        assert result is None
+
+    def test_execution_complete_sets_100(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="11", value=1, max=4))
+        assert mapper.update(ExecutionComplete(prompt_id="x")) == 100
+
+    def test_executing_null_node_sets_100(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="11", value=1, max=4))
+        assert mapper.update(Executing(node=None, prompt_id="x")) == 100
+
+    def test_wan22_synthetic_stream(self, plugin) -> None:
+        """Walk through a realistic WAN 2.2 i2v event sequence."""
+        mapper = plugin.progress_mapper()
+        events = [
+            Executing(node="1", prompt_id="p"),  # UNETLoader HIGH
+            Executing(node="2", prompt_id="p"),  # UNETLoader LOW
+            Executing(node="7", prompt_id="p"),  # LoadImage
+            Executing(node="10", prompt_id="p"),  # WanImageToVideo
+            Executing(node="11", prompt_id="p"),  # HIGH KSampler
+            Progress(node="11", value=1, max=4, prompt_id="p"),
+            Progress(node="11", value=2, max=4, prompt_id="p"),
+            Progress(node="11", value=3, max=4, prompt_id="p"),
+            Progress(node="11", value=4, max=4, prompt_id="p"),
+            Executing(node="12", prompt_id="p"),  # LOW KSampler
+            Progress(node="12", value=1, max=4, prompt_id="p"),
+            Progress(node="12", value=2, max=4, prompt_id="p"),
+            Progress(node="12", value=3, max=4, prompt_id="p"),
+            Progress(node="12", value=4, max=4, prompt_id="p"),
+            Executing(node="13", prompt_id="p"),  # VAEDecode (post-sample)
+            Executing(node="14", prompt_id="p"),  # VHS_VideoCombine
+            ExecutionComplete(prompt_id="p"),
+        ]
+        series = []
+        for ev in events:
+            pct = mapper.update(ev)
+            if pct is not None:
+                series.append(pct)
+        assert series[0] > 0
+        assert max(series) == 100
+        assert series == sorted(series)
+        assert 95 in series or any(p >= 95 for p in series)
+
+
+class TestRenderOutputs:
+    @pytest.mark.asyncio
+    async def test_builds_payload_with_mp4_attachment(
+        self, plugin, manifest, tmp_path: Path
+    ) -> None:
+        mp4_bytes = b"\x00\x00\x00\x20ftypmp42" + b"\x00" * 64
+        out_path = tmp_path / "wan22_i2v_00001.mp4"
+        out_path.write_bytes(mp4_bytes)
+        run = Run(
+            id=uuid.uuid4().hex,
+            manifest_id=manifest.id,
+            prompt_id="prompt-id-xyz",
+            slot_values={
+                "prompt": "camera pans right",
+                "negative_prompt": "blurry",
+                "init_image": "src.png",
+                "frame_count": 17,
+                "seed": 42,
+            },
+            status=RunStatus.COMPLETE,
+        )
+        output = Output(
+            role=Role.OUTPUT_VIDEO,
+            media="video/mp4",
+            path=out_path,
+            bytes_read=mp4_bytes,
+        )
+        payload = await plugin.render_outputs(run, [output])
+
+        assert payload.embed["title"] == manifest.id
+        field_names = [f["name"] for f in payload.embed["fields"]]
+        assert "Prompt" in field_names
+        assert "Negative" in field_names
+        assert "Frames" in field_names
+        assert "Duration" in field_names
+        assert "Seed" in field_names
+        assert "File size" in field_names
+        assert len(payload.files) == 1
+        assert payload.files[0].filename == "wan22_i2v_00001.mp4"
+        assert payload.files[0].content_type == "video/mp4"
+        assert payload.files[0].data == mp4_bytes
+        assert payload.content is None
+
+    @pytest.mark.asyncio
+    async def test_oversize_video_omits_attachment(
+        self, plugin, manifest, tmp_path: Path
+    ) -> None:
+        oversized = b"\x00" * (DISCORD_FILE_CAP_BYTES + 1024)
+        out_path = tmp_path / "huge.mp4"
+        out_path.write_bytes(oversized)
+        run = Run(
+            id="x",
+            manifest_id=manifest.id,
+            prompt_id="pid",
+            slot_values={"prompt": "x", "frame_count": 81},
+        )
+        output = Output(
+            role=Role.OUTPUT_VIDEO,
+            media="video/mp4",
+            path=out_path,
+            bytes_read=oversized,
+        )
+        payload = await plugin.render_outputs(run, [output])
+        assert payload.files == []
+        assert payload.content is not None
+        assert "huge.mp4" in payload.content
+        assert "/view" in payload.content
+        assert "description" in payload.embed
+        assert "too large" in payload.embed["description"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_outputs_yields_no_files(self, plugin, manifest) -> None:
+        run = Run(id="x", manifest_id=manifest.id)
+        payload = await plugin.render_outputs(run, [])
+        assert payload.files == []
+        assert "description" in payload.embed
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_prompt(
+        self, plugin, manifest, tmp_path: Path
+    ) -> None:
+        mp4 = b"\x00" * 128
+        out_path = tmp_path / "v.mp4"
+        out_path.write_bytes(mp4)
+        run = Run(
+            id="x",
+            manifest_id=manifest.id,
+            slot_values={"prompt": "x" * 5000},
+        )
+        output = Output(
+            role=Role.OUTPUT_VIDEO,
+            media="video/mp4",
+            path=out_path,
+            bytes_read=mp4,
+        )
+        payload = await plugin.render_outputs(run, [output])
+        prompt_field = next(
+            f for f in payload.embed["fields"] if f["name"] == "Prompt"
+        )
+        assert len(prompt_field["value"]) <= 1024
+
+
+class TestDefaultPostActions:
+    def test_returns_manifest_actions_verbatim(self, plugin, manifest) -> None:
+        actions = plugin.default_post_actions(manifest)
+        assert [a.id for a in actions] == [a.id for a in manifest.actions]
+        assert actions == []  # v3.0 wan22_i2v ships no actions yet

--- a/tests/test_wan22_manifest_loading.py
+++ b/tests/test_wan22_manifest_loading.py
@@ -1,0 +1,181 @@
+"""Manifest-loading + requires-validation tests for WAN 2.2 i2v.
+
+The manifest is the architectural test of ADR-0001's multi-UNET pattern:
+two ``requires.unets`` entries, two ``role: model_high`` / ``model_low``
+slots, two distinct UNETLoader targets.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.capability import Inventory
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "object_info_slim.json"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return load_manifest("workflows/manifests/wan22_i2v.yaml")
+
+
+@pytest.fixture(scope="module")
+def inventory() -> Inventory:
+    return Inventory(json.loads(FIXTURE.read_text(encoding="utf-8")))
+
+
+class TestManifestShape:
+    def test_id_and_modality(self, manifest) -> None:
+        assert manifest.id == "wan22_i2v"
+        assert manifest.modality == Modality.VIDEO
+
+    def test_declares_high_and_low_unet(self, manifest) -> None:
+        assert (
+            "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors"
+            in manifest.requires.unets
+        )
+        assert (
+            "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors"
+            in manifest.requires.unets
+        )
+
+    def test_declares_lora_pair(self, manifest) -> None:
+        assert (
+            "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors"
+            in manifest.requires.loras
+        )
+        assert (
+            "SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors"
+            in manifest.requires.loras
+        )
+
+    def test_has_model_high_and_low_slots(self, manifest) -> None:
+        by_name = manifest.slots_by_name()
+        assert by_name["model_high"].role == Role.MODEL_HIGH
+        assert by_name["model_low"].role == Role.MODEL_LOW
+
+    def test_init_image_slot_is_required(self, manifest) -> None:
+        slot = manifest.slots_by_name()["init_image"]
+        assert slot.role == Role.INIT_IMAGE
+        assert slot.ui.required is True
+        assert slot.ui.attachment_position == 1
+
+    def test_output_is_video_mp4(self, manifest) -> None:
+        assert len(manifest.outputs) == 1
+        assert manifest.outputs[0].role == Role.OUTPUT_VIDEO
+        assert manifest.outputs[0].media == "video/mp4"
+
+    def test_seed_targets_both_samplers(self, manifest) -> None:
+        seed = manifest.slots_by_name()["seed"]
+        targets = seed.resolved_targets()
+        target_nodes = sorted(t.node for t in targets)
+        assert target_nodes == ["11", "12"]
+
+
+class TestRequiresValidationAgainstInventory:
+    def test_fully_satisfied(self, manifest, inventory) -> None:
+        missing = inventory.validate_requires(manifest.requires)
+        assert missing == [], missing
+
+    def test_missing_high_unet_reports_high(self, manifest) -> None:
+        from core.manifest.schema import Requires
+
+        starved = Inventory(
+            {
+                "UNETLoader": {
+                    "input": {
+                        "required": {
+                            "unet_name": [
+                                [
+                                    "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "VAELoader": {
+                    "input": {
+                        "required": {
+                            "vae_name": [["wan_2.1_vae.safetensors"]]
+                        }
+                    }
+                },
+                "CLIPLoader": {
+                    "input": {
+                        "required": {
+                            "clip_name": [
+                                ["umt5_xxl_fp8_e4m3fn_scaled.safetensors"]
+                            ]
+                        }
+                    }
+                },
+                "LoraLoaderModelOnly": {
+                    "input": {
+                        "required": {
+                            "lora_name": [
+                                [
+                                    "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors",
+                                    "SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors",
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "AnyVHSNode": {
+                    "python_module": "custom_nodes.comfyui-videohelpersuite"
+                },
+            }
+        )
+        missing = starved.validate_requires(manifest.requires)
+        assert any("FP8H" in m for m in missing)
+        assert not any("FP8L" in m for m in missing)
+
+    def test_missing_lora_pair_reports_both(self, manifest) -> None:
+        starved = Inventory(
+            {
+                "UNETLoader": {
+                    "input": {
+                        "required": {
+                            "unet_name": [
+                                [
+                                    "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors",
+                                    "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors",
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "VAELoader": {
+                    "input": {
+                        "required": {
+                            "vae_name": [["wan_2.1_vae.safetensors"]]
+                        }
+                    }
+                },
+                "CLIPLoader": {
+                    "input": {
+                        "required": {
+                            "clip_name": [
+                                ["umt5_xxl_fp8_e4m3fn_scaled.safetensors"]
+                            ]
+                        }
+                    }
+                },
+                "LoraLoaderModelOnly": {
+                    "input": {
+                        "required": {"lora_name": [[]]}
+                    }
+                },
+                "AnyVHSNode": {
+                    "python_module": "custom_nodes.comfyui-videohelpersuite"
+                },
+            }
+        )
+        missing = starved.validate_requires(manifest.requires)
+        assert sum(1 for m in missing if "SVI_v2_PRO" in m) == 2

--- a/workflows/manifests/wan22_i2v.yaml
+++ b/workflows/manifests/wan22_i2v.yaml
@@ -1,0 +1,167 @@
+schema_version: 1
+id: wan22_i2v
+name: "WAN 2.2 i2v (HIGH+LOW)"
+description: |
+  WAN 2.2 image-to-video with the HIGH+LOW noise UNET pair. The HIGH-noise
+  UNET handles the early sampling timesteps (structural motion); the LOW-noise
+  UNET refines fine detail in a second KSampler pass. Each UNET is stacked
+  with its matching SVI_v2_PRO LoRA. Uses the canonical core ComfyUI
+  WanImageToVideo node for i2v latent assembly and VHS_VideoCombine for MP4
+  output at 16 fps. This manifest is the first exercise of ADR-0001's
+  multi-UNET pattern: two slots (model_high / model_low) target two
+  independent UNETLoader nodes.
+modality: video
+workflow_file: workflows/wan22_i2v.json
+
+requires:
+  packs:
+    - custom_nodes.comfyui-videohelpersuite
+  unets:
+    - wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors
+    - wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors
+  vaes:
+    - wan_2.1_vae.safetensors
+  clips:
+    - umt5_xxl_fp8_e4m3fn_scaled.safetensors
+  loras:
+    - SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors
+    - SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "8", field: "text" }
+    ui:
+      hint: long_text
+      label: "Prompt"
+      placeholder: "camera slowly pans right across..."
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "9", field: "text" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: "low quality, blurry, distorted, watermark, static"
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: init_image
+    type: image
+    role: init_image
+    target: { node: "7", field: "image" }
+    ui:
+      hint: image
+      label: "Source image"
+      required: true
+      attachment_position: 1
+    validation:
+      accepts: [image/png, image/jpeg, image/webp]
+
+  - name: model_high
+    type: enum_static
+    role: model_high
+    target: { node: "1", field: "unet_name" }
+    options:
+      - wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors
+    ui:
+      hint: select_static
+      label: "HIGH-noise UNET"
+      default: wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors
+      required: true
+
+  - name: model_low
+    type: enum_static
+    role: model_low
+    target: { node: "2", field: "unet_name" }
+    options:
+      - wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors
+    ui:
+      hint: select_static
+      label: "LOW-noise UNET"
+      default: wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors
+      required: true
+
+  - name: frame_count
+    type: int
+    role: batch_size
+    target: { node: "10", field: "length" }
+    ui:
+      hint: number
+      label: "Frame count"
+      default: 17
+      step: 4
+      required: false
+    validation:
+      min: 8
+      max: 81
+
+  - name: seed
+    type: seed
+    role: seed
+    targets:
+      - { node: "11", field: "seed" }
+      - { node: "12", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: cfg
+    type: float
+    role: cfg
+    targets:
+      - { node: "11", field: "cfg" }
+      - { node: "12", field: "cfg" }
+    ui:
+      hint: number
+      label: "CFG scale"
+      default: 6.0
+      step: 0.5
+      required: false
+    validation:
+      min: 1.0
+      max: 15.0
+
+  - name: steps_high
+    type: int
+    role: steps
+    target: { node: "11", field: "steps" }
+    ui:
+      hint: number
+      label: "Steps (HIGH pass)"
+      default: 4
+      step: 1
+      required: false
+    validation:
+      min: 2
+      max: 12
+
+  - name: steps_low
+    type: int
+    role: steps
+    target: { node: "12", field: "steps" }
+    ui:
+      hint: number
+      label: "Steps (LOW pass)"
+      default: 4
+      step: 1
+      required: false
+    validation:
+      min: 2
+      max: 12
+
+outputs:
+  - role: output_video
+    node: "14"
+    media: video/mp4
+
+actions: []

--- a/workflows/wan22_i2v.json
+++ b/workflows/wan22_i2v.json
@@ -1,0 +1,141 @@
+{
+  "1": {
+    "class_type": "UNETLoader",
+    "_meta": {"title": "Load Diffusion Model (HIGH noise)"},
+    "inputs": {
+      "unet_name": "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8H.safetensors",
+      "weight_dtype": "default"
+    }
+  },
+  "2": {
+    "class_type": "UNETLoader",
+    "_meta": {"title": "Load Diffusion Model (LOW noise)"},
+    "inputs": {
+      "unet_name": "wan22EnhancedNSFWCameraPrompt_nsfwFASTMOVEV2FP8L.safetensors",
+      "weight_dtype": "default"
+    }
+  },
+  "3": {
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {"title": "Load LoRA (HIGH)"},
+    "inputs": {
+      "model": ["1", 0],
+      "lora_name": "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors",
+      "strength_model": 1.0
+    }
+  },
+  "4": {
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {"title": "Load LoRA (LOW)"},
+    "inputs": {
+      "model": ["2", 0],
+      "lora_name": "SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors",
+      "strength_model": 1.0
+    }
+  },
+  "5": {
+    "class_type": "CLIPLoader",
+    "_meta": {"title": "Load CLIP (umt5 wan)"},
+    "inputs": {
+      "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+      "type": "wan"
+    }
+  },
+  "6": {
+    "class_type": "VAELoader",
+    "_meta": {"title": "Load VAE (wan 2.1)"},
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    }
+  },
+  "7": {
+    "class_type": "LoadImage",
+    "_meta": {"title": "Load Init Image"},
+    "inputs": {
+      "image": "placeholder.png"
+    }
+  },
+  "8": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Positive Prompt"},
+    "inputs": {
+      "text": "",
+      "clip": ["5", 0]
+    }
+  },
+  "9": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Negative Prompt"},
+    "inputs": {
+      "text": "low quality, blurry, distorted, watermark",
+      "clip": ["5", 0]
+    }
+  },
+  "10": {
+    "class_type": "WanImageToVideo",
+    "_meta": {"title": "Wan Image To Video"},
+    "inputs": {
+      "positive": ["8", 0],
+      "negative": ["9", 0],
+      "vae": ["6", 0],
+      "width": 832,
+      "height": 480,
+      "length": 17,
+      "batch_size": 1,
+      "start_image": ["7", 0]
+    }
+  },
+  "11": {
+    "class_type": "KSampler",
+    "_meta": {"title": "KSampler (HIGH-noise pass)"},
+    "inputs": {
+      "model": ["3", 0],
+      "seed": 0,
+      "steps": 4,
+      "cfg": 6.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "positive": ["10", 0],
+      "negative": ["10", 1],
+      "latent_image": ["10", 2],
+      "denoise": 1.0
+    }
+  },
+  "12": {
+    "class_type": "KSampler",
+    "_meta": {"title": "KSampler (LOW-noise pass)"},
+    "inputs": {
+      "model": ["4", 0],
+      "seed": 0,
+      "steps": 4,
+      "cfg": 6.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "positive": ["10", 0],
+      "negative": ["10", 1],
+      "latent_image": ["11", 0],
+      "denoise": 1.0
+    }
+  },
+  "13": {
+    "class_type": "VAEDecode",
+    "_meta": {"title": "VAE Decode"},
+    "inputs": {
+      "samples": ["12", 0],
+      "vae": ["6", 0]
+    }
+  },
+  "14": {
+    "class_type": "VHS_VideoCombine",
+    "_meta": {"title": "Combine to MP4"},
+    "inputs": {
+      "images": ["13", 0],
+      "frame_rate": 16,
+      "loop_count": 0,
+      "filename_prefix": "wan22_i2v",
+      "format": "video/h264-mp4",
+      "pingpong": false,
+      "save_output": true
+    }
+  }
+}


### PR DESCRIPTION
Closes #7. Slice 5 of the v3.0 milestone - introduces the `video` Modality
Plugin and exercises ADR-0001's multi-UNET manifest pattern for the first
time.

## What changed

- **`core/modalities/video/{__init__,plugin}.py`** - `VideoPlugin` implementing
  `ModalityPlugin`. `output_media=[\"video/mp4\"]`. Dual-sampler
  `ProgressMapper` sums HIGH+LOW `KSampler` step events into 0-95%, bumps
  2% per post-sampling `Executing` event (VAEDecode, VHS_VideoCombine) up
  to 99%, then 100% on `ExecutionComplete`. Renderer attaches MP4 + embed
  (prompt / frames / duration / size / seed); files over the 25 MB
  Discord cap fall back to a content message naming the ComfyUI
  `/view?filename=...&type=output` URL (external upload lands in v3.x).
- **`core/modalities/registry.py`** - register `VideoPlugin` alongside
  `ImageT2IPlugin`.
- **`workflows/wan22_i2v.json`** - HIGH+LOW UNETLoader pair, each stacked
  with its matching `SVI_v2_PRO` LoRA, `umt5_xxl_fp8_e4m3fn_scaled` CLIP
  (`type: wan`), `wan_2.1_vae`, `WanImageToVideo` for i2v latent assembly,
  dual `KSampler` (HIGH-noise -> LOW-noise refinement), `VAEDecode`,
  `VHS_VideoCombine` -> `video/h264-mp4` at 16 fps.
- **`workflows/manifests/wan22_i2v.yaml`** - 10 slots including
  `model_high` (`role: model_high`) and `model_low` (`role: model_low`)
  targeting the two distinct UNETLoader nodes. Multi-target slots (`seed`,
  `cfg`) land one value on both samplers. `requires{}` declares both
  UNETs, both LoRAs, umt5 CLIP, wan_2.1 VAE, and the
  `custom_nodes.comfyui-videohelpersuite` pack so a half-installed server
  fails registration cleanly. Outputs declare `output_video` mime
  `video/mp4`. Actions empty (post-video actions are v3.x).
- **`scripts/v3_smoke.py`** - IMAGE-typed slots whose value is a local
  file path are auto-uploaded via `/upload/image`; the slot is rewritten
  to the server-side filename before `apply_slots`. Video output collection
  walks a bucket priority list (`videos` -> `gifs` -> `files`) so we tolerate
  VHS_VideoCombine's legacy `gifs` key for MP4s.
- **`tests/test_video_plugin.py`** (24 tests) - plugin contract, validator
  coercion (including dict-shaped attachment values), dual-sampler
  ProgressMapper monotonicity + 95% sampling cap + post-sample bumps up
  to 99%, oversize-video renderer fallback.
- **`tests/test_wan22_manifest_loading.py`** - manifest shape + the
  Inventory.validate_requires path proves that a server missing one UNET
  reports HIGH-only and a server missing the LoRA pair reports both.
- **`tests/test_multi_unet_pattern.py`** - golden architectural test
  (this is the deliverable the slice was scoped around).
- **`tests/fixtures/object_info_slim.json`** - add `VHS_VideoCombine` +
  `WanImageToVideo` nodes so requires/pack validation can be exercised
  offline.

## Acceptance criteria

- [x] /video runs WAN 2.2 i2v with the source image fed into the i2v init
      slot - the manifest + JSON wire `init_image` -> `LoadImage(node 7)`
      -> `WanImageToVideo.start_image`; the v3_smoke harness uploads
      local paths automatically. The Discord slash command surface lands
      in a later slice that wires the unified `/run` command to manifests.
- [x] Multi-UNET manifest pattern documented with a working example
      (`workflows/manifests/wan22_i2v.yaml` IS the example, golden-tested
      in `tests/test_multi_unet_pattern.py`).
- [x] Progress bar reflects both sampling steps and frame assembly -
      `_DualSamplerProgressMapper` test `test_wan22_synthetic_stream`
      walks an end-to-end synthetic event stream and asserts the series
      is monotone and reaches 100%.
- [x] pytest covers video Plugin renderer + ProgressMapper.

## Test plan

- [x] `pytest -q` -> `239 passed, 1 skipped` in the worktree.
- [ ] Live smoke against `http://172.27.1.165:8188` is deferred
      (TODO_SMOKE). ComfyUI was unreachable from this agent's network
      (curl --max-time 5 timed out, error 28). Smoke playbook captured
      in `output/v3_smoke/SLICE_7_RUNS.md` (gitignored). Per the
      orchestrator's deferred-runs policy.

## Multi-UNET pattern evidence

`tests/test_multi_unet_pattern.py` asserts:

1. The workflow JSON declares two distinct `UNETLoader` nodes.
2. The manifest's `model_high` and `model_low` slots target those two
   distinct nodes.
3. `apply_slots` writes the HIGH filename into the HIGH-targeted node
   and the LOW filename into the LOW-targeted node.
4. Each `LoraLoaderModelOnly` stays wired to its matching UNET (HIGH
   LoRA on HIGH UNET, LOW LoRA on LOW UNET).
5. The multi-target `seed` slot lands the same integer on both samplers.
6. `steps_high` and `steps_low` each land on their distinct sampler.

No schema changes were required - the existing `role: model_high` /
`model_low` enum members + `target: { node, field }` + `targets: [...]`
mechanics already cover the WAN 2.2 dual-UNET pipeline.

## VRAM behaviour

Not yet observed (smoke deferred). Documented contingency in
`output/v3_smoke/SLICE_7_RUNS.md`: drop `frame_count` from 17 -> 9
(smallest Wan-valid `(length-1) % 4 == 0`), then drop width/height in the
workflow JSON to 512x480 before escalating to the user. Did NOT silently
lower the manifest defaults below the issue-requested fidelity.

## Notes / deviations from the issue text

- Issue requested `frame_count` default 16 - `WanImageToVideo` enforces
  `(length - 1) % 4 == 0`, so the manifest defaults to 17 (closest valid
  value above 16). Min stays at 8 as requested but the next valid value
  is 9. Documented in the runs log.
- The `frame_count` slot uses `role: batch_size` (the closest existing
  member of the closed Role enum in `core/manifest/roles.py`). Adding a
  dedicated `frame_count` role would be an ADR-level change outside
  this slice's scope; the existing roles are sufficient.

## Anchors

- PRD: video section, success criterion 2 (every Modality has at least
  one runnable manifest).
- ADR-0001: workflow-manifest format - multi-UNET mandatory schema rule 6.
- ADR-0002: Modality plugins, not per-model branches.
- ADR-0004: thin ComfyUI client + capability checks.

Made with [Cursor](https://cursor.com)