### PR TITLE
Slice 6: video LTX-Video 2.3 22B t2v + i2v (#8)

### DIFF
--- a/docs/v3/smoke/SLICE_6_RUNS.md
+++ b/docs/v3/smoke/SLICE_6_RUNS.md
@@ -40,3 +40,103 @@ its smoke is OPTIONAL until the operator installs an upscale model
 (e.g. `4x_foolhardy_Remacri.pth` under `ComfyUI/models/upscale_models`).
 Until then, `pytest tests/test_upscale_manifest_loading.py::TestPixelManifestIsConditional`
 verifies it stays disabled.
+
+---
+
+## Slice 6 (#8) - LTX-Video 2.3 22B t2v + i2v smoke runs
+
+**Status:** `LIVE_OK` - both manifests ran end-to-end against
+`http://172.27.1.165:8188` from worktree
+`/Users/jamievanderpijll/discomfy-slice-6-ltx`.
+
+### Server-side findings (recorded so the next slice picks them up)
+
+While iterating on the workflow we hit two server-side issues that the
+`/object_info` discovery alone could not predict:
+
+1. **`LTXVGemmaCLIPModelLoader` fails with `No files matching pattern 'tokenizer.model' ...`.**
+   The custom node expects a Gemma `tokenizer.model` sentencepiece file
+   bundled next to the safetensors weights. The server is missing it.
+   Replacement: the LTX 2.x successor `LTXAVTextEncoderLoader`
+   (`text_encoder=gemma_3_12B_it.safetensors`, `ckpt_name=ltx-2.3-22b-dev-fp8.safetensors`)
+   loads the same Gemma weights without that file and exports a
+   standard `CLIP` socket compatible with `CLIPTextEncode`.
+2. **`LTXVQ8LoraModelLoader` fails with `name 'hadamard_transform' is not defined`.**
+   The Q8 loader's runtime path imports `hadamard_transform` (a CUDA
+   kernel from `fast-hadamard-transform`) that is not installed on this
+   server. Replacement: plain `LoraLoaderModelOnly` accepts the same
+   `ltx-2.3-22b-distilled-lora-384.safetensors` file and produces
+   equivalent output for non-quantized use; switching loaders cost no
+   model files and dropped the dependency to "stock ComfyUI".
+3. **`LTXVGemmaEnhancePrompt` raised `min() iterable argument is empty`**
+   when fed the `LTXAVTextEncoderLoader`'s CLIP. Skipped; the user's
+   prompt is fed straight into `CLIPTextEncode`. If the operator wants
+   prompt enhancement back, install Gemma's `tokenizer.model` so
+   `LTXVGemmaCLIPModelLoader` becomes usable and switch the manifest's
+   `prompt` target back to its `prompt` field.
+
+These are logged here so a follow-up slice can fix the server install
+or revise the manifests once the Gemma tokenizer + Q8 dep land.
+
+### 1. T2V
+
+```bash
+COMFYUI_URL=http://172.27.1.165:8188 python scripts/v3_smoke.py \
+    --manifest ltxv_2_3_22b_t2v \
+    --slot prompt="a slow cinematic dolly across a foggy harbor at sunrise, gentle waves, soft golden light" \
+    --slot width=768 --slot height=512 \
+    --slot frame_count=49 \
+    --slot seed=12345 \
+    --timeout 900
+```
+
+- `prompt_id`: `5955945b-0162-4730-b886-99d82c1a42ca`
+- output: `output/v3_smoke/5955945b-0162-4730-b886-99d82c1a42ca/ltxv_2_3_22b_t2v_00001.mp4`
+- size: `384576` bytes (~376 KB)
+- wall-clock latency: `33.04 s`
+- progress shape: one `SamplerCustomAdvanced` `progress` stream (node 14, 1/8 -> 8/8 over ~16 s), then `VAEDecode` (node 15) + `VHS_VideoCombine` (node 16) as post-sample Executing events, then `ExecutionComplete`. The shared `VideoPlugin` `_DualSamplerProgressMapper` happily handled the single-stream variant - no code changes required (see `tests/test_video_plugin_ltx_compat.py::TestSingleSamplerProgressMapping`).
+
+### 2. I2V (chained from `qwen_image_2512`)
+
+The harness uploads the local source image via `/upload/image` and
+rewrites the `init_image` slot to the server-side filename before
+`apply_slots`:
+
+```bash
+# First generate a source image with Qwen-Image 2512.
+COMFYUI_URL=http://172.27.1.165:8188 python scripts/v3_smoke.py \
+    --manifest qwen_image_2512 \
+    --slot prompt="a single fluffy red panda standing on a moss-covered log in a misty forest at dawn, soft cinematic light, shallow depth of field" \
+    --slot width=1024 --slot height=1024 \
+    --slot seed=99
+# -> prompt_id=402f9033-617c-4413-8d2d-b39128c974ec
+# -> output/v3_smoke/402f9033-617c-4413-8d2d-b39128c974ec/final_output_00008_.png  (3126261 bytes)
+
+# Now animate it with LTX-Video 2.3 22B i2v.
+COMFYUI_URL=http://172.27.1.165:8188 python scripts/v3_smoke.py \
+    --manifest ltxv_2_3_22b_i2v \
+    --slot prompt="the red panda slowly turns its head toward the camera, soft breeze ruffling its fur, gentle drifting mist" \
+    --slot init_image=output/v3_smoke/402f9033-617c-4413-8d2d-b39128c974ec/final_output_00008_.png \
+    --slot width=768 --slot height=768 \
+    --slot frame_count=49 \
+    --slot seed=55 \
+    --timeout 900
+```
+
+- `prompt_id` (qwen source image): `402f9033-617c-4413-8d2d-b39128c974ec`
+- `prompt_id` (LTX i2v): `c043322d-886f-44da-902c-ce978248eb67`
+- output: `output/v3_smoke/c043322d-886f-44da-902c-ce978248eb67/ltxv_2_3_22b_i2v_00001.mp4`
+- size: `470635` bytes (~459 KB)
+- wall-clock latency: `42.85 s` (i2v Run only - excludes qwen source image generation)
+- the `init_image` slot was uploaded as `final_output_00008_.png` (`3126261` bytes) by `_upload_image_slots` and the slot value was rewritten before `apply_slots`. The `LTXVImgToVideo` node (id "9") then conditioned the latent on the uploaded frame.
+
+### Plugin reuse
+
+No `VideoPlugin` changes. The slice 5 dual-sampler progress mapper
+sums per-node `Progress` streams and gracefully degrades to a single
+stream for LTX's `SamplerCustomAdvanced`. The `validate_slot_values`
+coercion + bound enforcement and the MP4 `render_outputs` pipeline
+work as-is against the LTX manifests. See
+`tests/test_video_plugin_ltx_compat.py` for the synthetic stream and
+slot-validation coverage.
+

--- a/tests/test_ltxv_manifest_loading.py
+++ b/tests/test_ltxv_manifest_loading.py
@@ -1,0 +1,353 @@
+"""Manifest-loading + requires-validation tests for LTX-Video 2.3 22B.
+
+These manifests are the second `video` Modality member alongside
+wan22_i2v. They exercise:
+
+- a single-checkpoint model load (no UNET pair, unlike WAN 2.2);
+- a Gemma-3-12B CLIP encoder pinned via `requires.clips`;
+- the LTX Q8 distilled LoRA as the default `requires.loras` entry
+  and as the default value of the dynamic `lora` slot;
+- LTXVImgToVideo wiring for the i2v variant with an `init_image`
+  Slot exposed at attachment_position 1 so it can be chained from
+  qwen_image_2512's `output_image`.
+
+No live ComfyUI; the test reads ``object_info_slim.json`` and the
+workflow JSON files directly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.capability import Inventory
+from core.manifest import load_manifest
+from core.manifest.applier import apply_slots
+from core.manifest.roles import Modality, Role
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "object_info_slim.json"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def t2v_manifest():
+    return load_manifest("workflows/manifests/ltxv_2_3_22b_t2v.yaml")
+
+
+@pytest.fixture(scope="module")
+def i2v_manifest():
+    return load_manifest("workflows/manifests/ltxv_2_3_22b_i2v.yaml")
+
+
+@pytest.fixture(scope="module")
+def inventory() -> Inventory:
+    return Inventory(json.loads(FIXTURE.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="module")
+def t2v_workflow() -> dict:
+    return json.loads(
+        (REPO_ROOT / "workflows" / "ltxv_2_3_22b_t2v.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def i2v_workflow() -> dict:
+    return json.loads(
+        (REPO_ROOT / "workflows" / "ltxv_2_3_22b_i2v.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+class TestT2VManifestShape:
+    def test_id_and_modality(self, t2v_manifest) -> None:
+        assert t2v_manifest.id == "ltxv_2_3_22b_t2v"
+        assert t2v_manifest.modality == Modality.VIDEO
+
+    def test_requires_checkpoint_clip_and_lora(self, t2v_manifest) -> None:
+        assert "ltx-2.3-22b-dev-fp8.safetensors" in t2v_manifest.requires.checkpoints
+        assert "gemma_3_12B_it.safetensors" in t2v_manifest.requires.clips
+        assert (
+            "ltx-2.3-22b-distilled-lora-384.safetensors"
+            in t2v_manifest.requires.loras
+        )
+
+    def test_no_unets_required(self, t2v_manifest) -> None:
+        assert t2v_manifest.requires.unets == []
+        assert t2v_manifest.requires.vaes == []
+
+    def test_slot_roles(self, t2v_manifest) -> None:
+        by_name = t2v_manifest.slots_by_name()
+        assert by_name["prompt"].role == Role.PROMPT_POSITIVE
+        assert by_name["negative_prompt"].role == Role.PROMPT_NEGATIVE
+        assert by_name["width"].role == Role.LATENT_SIZE
+        assert by_name["height"].role == Role.LATENT_SIZE
+        assert by_name["frame_count"].role == Role.BATCH_SIZE
+        assert by_name["seed"].role == Role.SEED
+        assert by_name["lora"].role == Role.LORA
+        assert by_name["lora_strength"].role == Role.LORA_STRENGTH
+
+    def test_prompt_targets_clip_text_encode(self, t2v_manifest) -> None:
+        slot = t2v_manifest.slots_by_name()["prompt"]
+        targets = slot.resolved_targets()
+        assert len(targets) == 1
+        assert targets[0].node == "6"
+        assert targets[0].field == "text"
+
+    def test_lora_options_from_inventory(self, t2v_manifest) -> None:
+        slot = t2v_manifest.slots_by_name()["lora"]
+        assert slot.options_from == "comfyui.loras"
+
+    def test_output_is_video_mp4(self, t2v_manifest) -> None:
+        assert len(t2v_manifest.outputs) == 1
+        assert t2v_manifest.outputs[0].role == Role.OUTPUT_VIDEO
+        assert t2v_manifest.outputs[0].media == "video/mp4"
+        assert t2v_manifest.outputs[0].node == "16"
+
+
+class TestI2VManifestShape:
+    def test_id_and_modality(self, i2v_manifest) -> None:
+        assert i2v_manifest.id == "ltxv_2_3_22b_i2v"
+        assert i2v_manifest.modality == Modality.VIDEO
+
+    def test_requires_match_t2v(self, i2v_manifest, t2v_manifest) -> None:
+        assert i2v_manifest.requires.checkpoints == t2v_manifest.requires.checkpoints
+        assert i2v_manifest.requires.clips == t2v_manifest.requires.clips
+        assert i2v_manifest.requires.loras == t2v_manifest.requires.loras
+        assert i2v_manifest.requires.packs == t2v_manifest.requires.packs
+
+    def test_init_image_slot_required_with_attachment_position(
+        self, i2v_manifest
+    ) -> None:
+        slot = i2v_manifest.slots_by_name()["init_image"]
+        assert slot.role == Role.INIT_IMAGE
+        assert slot.ui.required is True
+        assert slot.ui.attachment_position == 1
+        targets = slot.resolved_targets()
+        assert targets[0].node == "8"
+        assert targets[0].field == "image"
+
+    def test_size_slots_target_imgtovideo_node(self, i2v_manifest) -> None:
+        by_name = i2v_manifest.slots_by_name()
+        for name in ("width", "height", "frame_count"):
+            tgt = by_name[name].resolved_targets()[0]
+            assert tgt.node == "9", f"{name} should target LTXVImgToVideo node"
+
+    def test_output_is_video_mp4(self, i2v_manifest) -> None:
+        assert len(i2v_manifest.outputs) == 1
+        assert i2v_manifest.outputs[0].role == Role.OUTPUT_VIDEO
+        assert i2v_manifest.outputs[0].media == "video/mp4"
+        assert i2v_manifest.outputs[0].node == "17"
+
+
+class TestRequiresValidationAgainstInventory:
+    def test_t2v_requires_satisfied(self, t2v_manifest, inventory) -> None:
+        missing = inventory.validate_requires(t2v_manifest.requires)
+        assert missing == [], missing
+
+    def test_i2v_requires_satisfied(self, i2v_manifest, inventory) -> None:
+        missing = inventory.validate_requires(i2v_manifest.requires)
+        assert missing == [], missing
+
+    def test_missing_checkpoint_is_reported(self, t2v_manifest) -> None:
+        starved = Inventory(
+            {
+                "CheckpointLoaderSimple": {
+                    "input": {
+                        "required": {"ckpt_name": [[]]}
+                    }
+                },
+                "CLIPLoader": {
+                    "input": {
+                        "required": {
+                            "clip_name": [["gemma_3_12B_it.safetensors"]]
+                        }
+                    }
+                },
+                "LoraLoaderModelOnly": {
+                    "input": {
+                        "required": {
+                            "lora_name": [
+                                ["ltx-2.3-22b-distilled-lora-384.safetensors"]
+                            ]
+                        }
+                    }
+                },
+                "AnyVHSNode": {
+                    "python_module": "custom_nodes.comfyui-videohelpersuite"
+                },
+            }
+        )
+        missing = starved.validate_requires(t2v_manifest.requires)
+        assert any(
+            "ltx-2.3-22b-dev-fp8.safetensors" in m for m in missing
+        ), missing
+
+    def test_missing_lora_is_reported(self, t2v_manifest) -> None:
+        starved = Inventory(
+            {
+                "CheckpointLoaderSimple": {
+                    "input": {
+                        "required": {
+                            "ckpt_name": [["ltx-2.3-22b-dev-fp8.safetensors"]]
+                        }
+                    }
+                },
+                "CLIPLoader": {
+                    "input": {
+                        "required": {
+                            "clip_name": [["gemma_3_12B_it.safetensors"]]
+                        }
+                    }
+                },
+                "LoraLoaderModelOnly": {
+                    "input": {"required": {"lora_name": [[]]}}
+                },
+                "AnyVHSNode": {
+                    "python_module": "custom_nodes.comfyui-videohelpersuite"
+                },
+            }
+        )
+        missing = starved.validate_requires(t2v_manifest.requires)
+        assert any(
+            "ltx-2.3-22b-distilled-lora-384.safetensors" in m for m in missing
+        ), missing
+
+
+class TestSlotsMapToWorkflowNodes:
+    """Every Slot's target node/field must exist in its workflow JSON."""
+
+    def test_t2v_slots_resolve(self, t2v_manifest, t2v_workflow) -> None:
+        for slot in t2v_manifest.slots:
+            for target in slot.resolved_targets():
+                node = t2v_workflow.get(target.node)
+                assert node is not None, (
+                    f"t2v slot '{slot.name}' targets missing node '{target.node}'"
+                )
+                inputs = node.get("inputs", {})
+                assert target.field in inputs, (
+                    f"t2v slot '{slot.name}' targets unknown field "
+                    f"'{target.field}' on node '{target.node}' ({sorted(inputs)})"
+                )
+
+    def test_i2v_slots_resolve(self, i2v_manifest, i2v_workflow) -> None:
+        for slot in i2v_manifest.slots:
+            for target in slot.resolved_targets():
+                node = i2v_workflow.get(target.node)
+                assert node is not None, (
+                    f"i2v slot '{slot.name}' targets missing node '{target.node}'"
+                )
+                inputs = node.get("inputs", {})
+                assert target.field in inputs, (
+                    f"i2v slot '{slot.name}' targets unknown field "
+                    f"'{target.field}' on node '{target.node}' ({sorted(inputs)})"
+                )
+
+    def test_t2v_output_node_exists(self, t2v_manifest, t2v_workflow) -> None:
+        for out in t2v_manifest.outputs:
+            assert out.node in t2v_workflow, (
+                f"t2v output node '{out.node}' missing from workflow JSON"
+            )
+
+    def test_i2v_output_node_exists(self, i2v_manifest, i2v_workflow) -> None:
+        for out in i2v_manifest.outputs:
+            assert out.node in i2v_workflow, (
+                f"i2v output node '{out.node}' missing from workflow JSON"
+            )
+
+    def test_t2v_uses_lora_loader_model_only(self, t2v_workflow) -> None:
+        # NOTE: we tried LTXVQ8LoraModelLoader first (per the slice 6 issue
+        # hint) but the live server is missing the `hadamard_transform`
+        # Python dependency it needs. The plain ComfyUI LoraLoaderModelOnly
+        # works for this LoRA and produces equivalent output for non-Q8 use.
+        assert t2v_workflow["3"]["class_type"] == "LoraLoaderModelOnly"
+        assert (
+            t2v_workflow["3"]["inputs"]["lora_name"]
+            == "ltx-2.3-22b-distilled-lora-384.safetensors"
+        )
+
+    def test_t2v_uses_ltxav_text_encoder_loader(self, t2v_workflow) -> None:
+        assert t2v_workflow["2"]["class_type"] == "LTXAVTextEncoderLoader"
+        assert (
+            t2v_workflow["2"]["inputs"]["text_encoder"]
+            == "gemma_3_12B_it.safetensors"
+        )
+        assert (
+            t2v_workflow["2"]["inputs"]["ckpt_name"]
+            == "ltx-2.3-22b-dev-fp8.safetensors"
+        )
+
+    def test_i2v_uses_ltxav_text_encoder_loader(self, i2v_workflow) -> None:
+        assert i2v_workflow["2"]["class_type"] == "LTXAVTextEncoderLoader"
+        assert (
+            i2v_workflow["2"]["inputs"]["text_encoder"]
+            == "gemma_3_12B_it.safetensors"
+        )
+
+    def test_i2v_uses_ltxv_img_to_video(self, i2v_workflow) -> None:
+        assert i2v_workflow["9"]["class_type"] == "LTXVImgToVideo"
+
+    def test_t2v_uses_empty_ltxv_latent(self, t2v_workflow) -> None:
+        assert t2v_workflow["8"]["class_type"] == "EmptyLTXVLatentVideo"
+
+
+class TestApplySlots:
+    """End-to-end: user values flow through apply_slots into the workflow."""
+
+    def test_t2v_apply_writes_user_values(
+        self, t2v_manifest, t2v_workflow
+    ) -> None:
+        updated = apply_slots(
+            t2v_workflow,
+            t2v_manifest,
+            {
+                "prompt": "a slow cinematic pan across a misty harbor at dawn",
+                "negative_prompt": "blurry",
+                "width": 640,
+                "height": 384,
+                "frame_count": 49,
+                "seed": 12345,
+                "lora": "ltx-2.3-22b-distilled-lora-384.safetensors",
+                "lora_strength": 1.0,
+            },
+        )
+        assert (
+            updated["6"]["inputs"]["text"]
+            == "a slow cinematic pan across a misty harbor at dawn"
+        )
+        assert updated["7"]["inputs"]["text"] == "blurry"
+        assert updated["8"]["inputs"]["width"] == 640
+        assert updated["8"]["inputs"]["height"] == 384
+        assert updated["8"]["inputs"]["length"] == 49
+        assert updated["13"]["inputs"]["noise_seed"] == 12345
+        assert (
+            updated["3"]["inputs"]["lora_name"]
+            == "ltx-2.3-22b-distilled-lora-384.safetensors"
+        )
+
+    def test_i2v_apply_writes_init_image_filename(
+        self, i2v_manifest, i2v_workflow
+    ) -> None:
+        updated = apply_slots(
+            i2v_workflow,
+            i2v_manifest,
+            {
+                "prompt": "the subject turns slowly",
+                "init_image": "uploaded_qwen_frame.png",
+                "width": 768,
+                "height": 768,
+                "frame_count": 97,
+                "seed": 7,
+            },
+        )
+        assert updated["8"]["inputs"]["image"] == "uploaded_qwen_frame.png"
+        assert updated["9"]["inputs"]["width"] == 768
+        assert updated["9"]["inputs"]["height"] == 768
+        assert updated["9"]["inputs"]["length"] == 97
+        assert updated["14"]["inputs"]["noise_seed"] == 7

--- a/tests/test_video_plugin_ltx_compat.py
+++ b/tests/test_video_plugin_ltx_compat.py
@@ -1,0 +1,255 @@
+"""VideoPlugin compatibility tests with the LTX-Video 2.3 22B manifests.
+
+The VideoPlugin (slice 5) was designed around the WAN 2.2 dual-KSampler
+pattern (two `Progress` streams, one per UNET pass). The LTX-Video
+manifests use a single `SamplerCustomAdvanced` node so they emit only
+one `Progress` stream. The mapper must handle that gracefully without
+any code change.
+
+This module also exercises ``validate_slot_values`` against both LTX
+manifests to confirm the shared coerce/enforce path works for the
+LTX-specific slot shapes (frame_count multiple_of=8, width/height
+multiple_of=32, dynamic LoRA enum, optional init_image), and re-uses
+``render_outputs`` with synthetic Output bytes to confirm the embed
+carries the LTX manifest id and the per-Slot fields the plugin extracts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.ws import (
+    Executing,
+    ExecutionComplete,
+    Progress,
+    Reconnected,
+)
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+from core.modalities.base import SlotValueValidationError
+from core.modalities.video.plugin import (
+    DEFAULT_VIDEO_FPS,
+    DISCORD_FILE_CAP_BYTES,
+    VideoPlugin,
+)
+from core.run import Output, Run, RunStatus
+
+
+@pytest.fixture
+def plugin() -> VideoPlugin:
+    return VideoPlugin()
+
+
+@pytest.fixture
+def t2v_manifest():
+    return load_manifest("workflows/manifests/ltxv_2_3_22b_t2v.yaml")
+
+
+@pytest.fixture
+def i2v_manifest():
+    return load_manifest("workflows/manifests/ltxv_2_3_22b_i2v.yaml")
+
+
+class TestLTXManifestsLoadUnderVideoPlugin:
+    def test_t2v_modality_is_video(self, t2v_manifest, plugin) -> None:
+        assert t2v_manifest.modality == plugin.modality
+        assert plugin.output_media == ["video/mp4"]
+
+    def test_i2v_modality_is_video(self, i2v_manifest, plugin) -> None:
+        assert i2v_manifest.modality == plugin.modality
+
+    @pytest.mark.asyncio
+    async def test_t2v_validate_coerces_dimensions_and_seed(
+        self, plugin, t2v_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            t2v_manifest,
+            {
+                "prompt": "a calm ocean wave at dusk",
+                "width": "768",
+                "height": "512",
+                "frame_count": "97",
+                "seed": "random",
+                "lora_strength": "0.8",
+            },
+        )
+        assert out["width"] == 768
+        assert out["height"] == 512
+        assert out["frame_count"] == 97
+        assert isinstance(out["seed"], int)
+        assert out["lora_strength"] == pytest.approx(0.8)
+
+    @pytest.mark.asyncio
+    async def test_t2v_rejects_below_min_frame_count(
+        self, plugin, t2v_manifest
+    ) -> None:
+        # LTX requires length = 1 + 8k; we keep min=9 but no multiple_of
+        # constraint since the (8k+1) pattern doesn't fit `multiple_of`.
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                t2v_manifest,
+                {"prompt": "x", "frame_count": "4"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_t2v_rejects_over_max_frame_count(
+        self, plugin, t2v_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                t2v_manifest,
+                {"prompt": "x", "frame_count": "1024"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_t2v_rejects_off_multiple_width(
+        self, plugin, t2v_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                t2v_manifest,
+                {"prompt": "x", "width": "770"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_i2v_accepts_init_image_filename(
+        self, plugin, i2v_manifest
+    ) -> None:
+        out = await plugin.validate_slot_values(
+            i2v_manifest,
+            {
+                "prompt": "the subject turns",
+                "init_image": "uploaded_qwen_frame.png",
+                "frame_count": "97",
+            },
+        )
+        assert out["init_image"] == "uploaded_qwen_frame.png"
+        assert out["frame_count"] == 97
+
+    @pytest.mark.asyncio
+    async def test_i2v_rejects_unknown_slot(
+        self, plugin, i2v_manifest
+    ) -> None:
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                i2v_manifest,
+                {"prompt": "x", "init_image": "x.png", "not_a_slot": 1},
+            )
+
+
+class TestSingleSamplerProgressMapping:
+    """LTX uses one SamplerCustomAdvanced node; the mapper must cope."""
+
+    def test_single_sampler_climbs_to_95(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        outputs = []
+        for v in range(1, 9):
+            outputs.append(mapper.update(Progress(node="14", value=v, max=8)))
+        filtered = [p for p in outputs if p is not None]
+        assert filtered == sorted(filtered), filtered
+        assert filtered[-1] == 95
+
+    def test_post_sample_bump_after_single_stream(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="14", value=8, max=8))
+        decode = mapper.update(Executing(node="15", prompt_id="p"))
+        combine = mapper.update(Executing(node="16", prompt_id="p"))
+        assert decode == 97
+        assert combine == 99
+
+    def test_ltx_synthetic_event_stream(self, plugin) -> None:
+        """Walk through a realistic LTX t2v event order."""
+        mapper = plugin.progress_mapper()
+        events = [
+            Executing(node="1", prompt_id="p"),  # CheckpointLoaderSimple
+            Executing(node="2", prompt_id="p"),  # GemmaCLIPModelLoader
+            Executing(node="3", prompt_id="p"),  # Q8 LoRA loader
+            Executing(node="4", prompt_id="p"),  # ModelSamplingLTXV
+            Executing(node="5", prompt_id="p"),  # GemmaEnhancePrompt
+            Executing(node="6", prompt_id="p"),  # CLIPTextEncode +
+            Executing(node="7", prompt_id="p"),  # CLIPTextEncode -
+            Executing(node="8", prompt_id="p"),  # EmptyLTXVLatentVideo
+            Executing(node="14", prompt_id="p"),  # SamplerCustomAdvanced
+            Progress(node="14", value=1, max=8, prompt_id="p"),
+            Progress(node="14", value=4, max=8, prompt_id="p"),
+            Progress(node="14", value=8, max=8, prompt_id="p"),
+            Executing(node="15", prompt_id="p"),  # VAEDecode
+            Executing(node="16", prompt_id="p"),  # VHS_VideoCombine
+            ExecutionComplete(prompt_id="p"),
+        ]
+        series = []
+        for ev in events:
+            pct = mapper.update(ev)
+            if pct is not None:
+                series.append(pct)
+        assert series[0] > 0
+        assert series == sorted(series)
+        assert series[-1] == 100
+        assert max(s for s in series if s < 100) >= 95
+
+    def test_reconnect_replays_last_pct(self, plugin) -> None:
+        mapper = plugin.progress_mapper()
+        mapper.update(Progress(node="14", value=3, max=8))
+        last = mapper.update(Reconnected())
+        assert last is not None
+
+
+class TestRenderOutputsForLTXManifests:
+    @pytest.mark.asyncio
+    async def test_t2v_render_carries_size_and_seed(
+        self, plugin, t2v_manifest, tmp_path: Path
+    ) -> None:
+        data = b"\x00\x00\x00\x20ftypmp42" + b"\x00" * 256
+        out_path = tmp_path / "ltxv_t2v_00001.mp4"
+        out_path.write_bytes(data)
+        run = Run(
+            id=uuid.uuid4().hex,
+            manifest_id=t2v_manifest.id,
+            prompt_id="prompt-id-ltx-t2v",
+            slot_values={
+                "prompt": "a slow cinematic pan",
+                "negative_prompt": "static",
+                "width": 768,
+                "height": 512,
+                "frame_count": 97,
+                "seed": 11,
+            },
+            status=RunStatus.COMPLETE,
+        )
+        output = Output(
+            role=Role.OUTPUT_VIDEO,
+            media="video/mp4",
+            path=out_path,
+            bytes_read=data,
+        )
+        payload = await plugin.render_outputs(run, [output])
+        assert payload.embed["title"] == t2v_manifest.id
+        names = [f["name"] for f in payload.embed["fields"]]
+        assert "Prompt" in names
+        assert "Frames" in names
+        assert "Size" in names
+        assert "Seed" in names
+        assert len(payload.files) == 1
+        assert payload.files[0].filename == "ltxv_t2v_00001.mp4"
+
+    @pytest.mark.asyncio
+    async def test_i2v_render_with_no_outputs(
+        self, plugin, i2v_manifest
+    ) -> None:
+        run = Run(id="x", manifest_id=i2v_manifest.id)
+        payload = await plugin.render_outputs(run, [])
+        assert payload.files == []
+        assert "description" in payload.embed
+
+
+class TestDefaultPostActions:
+    def test_t2v_actions_passthrough(self, plugin, t2v_manifest) -> None:
+        actions = plugin.default_post_actions(t2v_manifest)
+        assert actions == []  # t2v ships no post-Actions
+
+    def test_i2v_actions_passthrough(self, plugin, i2v_manifest) -> None:
+        actions = plugin.default_post_actions(i2v_manifest)
+        assert actions == []  # i2v ships no post-Actions either

--- a/workflows/ltxv_2_3_22b_i2v.json
+++ b/workflows/ltxv_2_3_22b_i2v.json
@@ -1,0 +1,150 @@
+{
+  "1": {
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {"title": "Load LTX-Video 2.3 22B Checkpoint"},
+    "inputs": {
+      "ckpt_name": "ltx-2.3-22b-dev-fp8.safetensors"
+    }
+  },
+  "2": {
+    "class_type": "LTXAVTextEncoderLoader",
+    "_meta": {"title": "Load LTX 2.x AV Text Encoder (Gemma)"},
+    "inputs": {
+      "text_encoder": "gemma_3_12B_it.safetensors",
+      "ckpt_name": "ltx-2.3-22b-dev-fp8.safetensors",
+      "device": "default"
+    }
+  },
+  "3": {
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {"title": "Load LTX Distilled LoRA"},
+    "inputs": {
+      "model": ["1", 0],
+      "lora_name": "ltx-2.3-22b-distilled-lora-384.safetensors",
+      "strength_model": 1.0
+    }
+  },
+  "4": {
+    "class_type": "ModelSamplingLTXV",
+    "_meta": {"title": "ModelSamplingLTXV"},
+    "inputs": {
+      "model": ["3", 0],
+      "max_shift": 2.05,
+      "base_shift": 0.95
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Positive Prompt"},
+    "inputs": {
+      "text": "",
+      "clip": ["2", 0]
+    }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Negative Prompt"},
+    "inputs": {
+      "text": "low quality, blurry, distorted, watermark, static, glitchy",
+      "clip": ["2", 0]
+    }
+  },
+  "8": {
+    "class_type": "LoadImage",
+    "_meta": {"title": "Load Init Image"},
+    "inputs": {
+      "image": "placeholder.png"
+    }
+  },
+  "9": {
+    "class_type": "LTXVImgToVideo",
+    "_meta": {"title": "LTXV Img To Video"},
+    "inputs": {
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "vae": ["1", 2],
+      "image": ["8", 0],
+      "width": 768,
+      "height": 512,
+      "length": 97,
+      "batch_size": 1,
+      "strength": 1.0
+    }
+  },
+  "10": {
+    "class_type": "LTXVConditioning",
+    "_meta": {"title": "LTXV Conditioning (frame_rate)"},
+    "inputs": {
+      "positive": ["9", 0],
+      "negative": ["9", 1],
+      "frame_rate": 25.0
+    }
+  },
+  "11": {
+    "class_type": "LTXVScheduler",
+    "_meta": {"title": "LTXV Scheduler"},
+    "inputs": {
+      "steps": 8,
+      "max_shift": 2.05,
+      "base_shift": 0.95,
+      "stretch": true,
+      "terminal": 0.1
+    }
+  },
+  "12": {
+    "class_type": "CFGGuider",
+    "_meta": {"title": "CFG Guider"},
+    "inputs": {
+      "model": ["4", 0],
+      "positive": ["10", 0],
+      "negative": ["10", 1],
+      "cfg": 3.0
+    }
+  },
+  "13": {
+    "class_type": "KSamplerSelect",
+    "_meta": {"title": "Sampler (euler)"},
+    "inputs": {
+      "sampler_name": "euler"
+    }
+  },
+  "14": {
+    "class_type": "RandomNoise",
+    "_meta": {"title": "RandomNoise"},
+    "inputs": {
+      "noise_seed": 0
+    }
+  },
+  "15": {
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {"title": "SamplerCustomAdvanced"},
+    "inputs": {
+      "noise": ["14", 0],
+      "guider": ["12", 0],
+      "sampler": ["13", 0],
+      "sigmas": ["11", 0],
+      "latent_image": ["9", 2]
+    }
+  },
+  "16": {
+    "class_type": "VAEDecode",
+    "_meta": {"title": "VAE Decode"},
+    "inputs": {
+      "samples": ["15", 0],
+      "vae": ["1", 2]
+    }
+  },
+  "17": {
+    "class_type": "VHS_VideoCombine",
+    "_meta": {"title": "Combine to MP4"},
+    "inputs": {
+      "images": ["16", 0],
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "ltxv_2_3_22b_i2v",
+      "format": "video/h264-mp4",
+      "pingpong": false,
+      "save_output": true
+    }
+  }
+}

--- a/workflows/ltxv_2_3_22b_t2v.json
+++ b/workflows/ltxv_2_3_22b_t2v.json
@@ -1,0 +1,138 @@
+{
+  "1": {
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {"title": "Load LTX-Video 2.3 22B Checkpoint"},
+    "inputs": {
+      "ckpt_name": "ltx-2.3-22b-dev-fp8.safetensors"
+    }
+  },
+  "2": {
+    "class_type": "LTXAVTextEncoderLoader",
+    "_meta": {"title": "Load LTX 2.x AV Text Encoder (Gemma)"},
+    "inputs": {
+      "text_encoder": "gemma_3_12B_it.safetensors",
+      "ckpt_name": "ltx-2.3-22b-dev-fp8.safetensors",
+      "device": "default"
+    }
+  },
+  "3": {
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {"title": "Load LTX Distilled LoRA"},
+    "inputs": {
+      "model": ["1", 0],
+      "lora_name": "ltx-2.3-22b-distilled-lora-384.safetensors",
+      "strength_model": 1.0
+    }
+  },
+  "4": {
+    "class_type": "ModelSamplingLTXV",
+    "_meta": {"title": "ModelSamplingLTXV"},
+    "inputs": {
+      "model": ["3", 0],
+      "max_shift": 2.05,
+      "base_shift": 0.95
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Positive Prompt"},
+    "inputs": {
+      "text": "",
+      "clip": ["2", 0]
+    }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "_meta": {"title": "Negative Prompt"},
+    "inputs": {
+      "text": "low quality, blurry, distorted, watermark, static, glitchy",
+      "clip": ["2", 0]
+    }
+  },
+  "8": {
+    "class_type": "EmptyLTXVLatentVideo",
+    "_meta": {"title": "Empty LTX Latent"},
+    "inputs": {
+      "width": 768,
+      "height": 512,
+      "length": 97,
+      "batch_size": 1
+    }
+  },
+  "9": {
+    "class_type": "LTXVConditioning",
+    "_meta": {"title": "LTXV Conditioning (frame_rate)"},
+    "inputs": {
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "frame_rate": 25.0
+    }
+  },
+  "10": {
+    "class_type": "LTXVScheduler",
+    "_meta": {"title": "LTXV Scheduler"},
+    "inputs": {
+      "steps": 8,
+      "max_shift": 2.05,
+      "base_shift": 0.95,
+      "stretch": true,
+      "terminal": 0.1
+    }
+  },
+  "11": {
+    "class_type": "CFGGuider",
+    "_meta": {"title": "CFG Guider"},
+    "inputs": {
+      "model": ["4", 0],
+      "positive": ["9", 0],
+      "negative": ["9", 1],
+      "cfg": 3.0
+    }
+  },
+  "12": {
+    "class_type": "KSamplerSelect",
+    "_meta": {"title": "Sampler (euler)"},
+    "inputs": {
+      "sampler_name": "euler"
+    }
+  },
+  "13": {
+    "class_type": "RandomNoise",
+    "_meta": {"title": "RandomNoise"},
+    "inputs": {
+      "noise_seed": 0
+    }
+  },
+  "14": {
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {"title": "SamplerCustomAdvanced"},
+    "inputs": {
+      "noise": ["13", 0],
+      "guider": ["11", 0],
+      "sampler": ["12", 0],
+      "sigmas": ["10", 0],
+      "latent_image": ["8", 0]
+    }
+  },
+  "15": {
+    "class_type": "VAEDecode",
+    "_meta": {"title": "VAE Decode"},
+    "inputs": {
+      "samples": ["14", 0],
+      "vae": ["1", 2]
+    }
+  },
+  "16": {
+    "class_type": "VHS_VideoCombine",
+    "_meta": {"title": "Combine to MP4"},
+    "inputs": {
+      "images": ["15", 0],
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "ltxv_2_3_22b_t2v",
+      "format": "video/h264-mp4",
+      "pingpong": false,
+      "save_output": true
+    }
+  }
+}

--- a/workflows/manifests/ltxv_2_3_22b_i2v.yaml
+++ b/workflows/manifests/ltxv_2_3_22b_i2v.yaml
@@ -1,0 +1,148 @@
+schema_version: 1
+id: ltxv_2_3_22b_i2v
+name: "LTX-Video 2.3 22B (image-to-video)"
+description: |
+  LTX-Video 2.3 22B image-to-video. Same loaders as the t2v sibling
+  (CheckpointLoaderSimple + LTXAVTextEncoderLoader + LoraLoaderModelOnly
+  + ModelSamplingLTXV), but LTXVImgToVideo replaces EmptyLTXVLatentVideo
+  and conditions the latent on a user-supplied first frame. The sampling
+  chain is otherwise identical: LTXVScheduler -> CFGGuider + KSamplerSelect
+  + RandomNoise -> SamplerCustomAdvanced -> VAEDecode -> VHS_VideoCombine.
+  Wired up as a chained Action target from qwen_image_2512 so a finished
+  Qwen image can be animated end-to-end.
+modality: video
+workflow_file: workflows/ltxv_2_3_22b_i2v.json
+
+requires:
+  packs:
+    - custom_nodes.comfyui-videohelpersuite
+  checkpoints:
+    - ltx-2.3-22b-dev-fp8.safetensors
+  clips:
+    - gemma_3_12B_it.safetensors
+  loras:
+    - ltx-2.3-22b-distilled-lora-384.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "6", field: "text" }
+    ui:
+      hint: long_text
+      label: "Prompt"
+      placeholder: "the subject slowly turns toward the camera, soft breeze..."
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "7", field: "text" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: "low quality, blurry, distorted, watermark, static, glitchy"
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: init_image
+    type: image
+    role: init_image
+    target: { node: "8", field: "image" }
+    ui:
+      hint: image
+      label: "Source image"
+      required: true
+      attachment_position: 1
+    validation:
+      accepts: [image/png, image/jpeg, image/webp]
+
+  - name: width
+    type: int
+    role: latent_size
+    target: { node: "9", field: "width" }
+    ui:
+      hint: number
+      label: "Width"
+      default: 768
+      step: 32
+      required: false
+    validation:
+      min: 384
+      max: 1280
+      multiple_of: 32
+
+  - name: height
+    type: int
+    role: latent_size
+    target: { node: "9", field: "height" }
+    ui:
+      hint: number
+      label: "Height"
+      default: 512
+      step: 32
+      required: false
+    validation:
+      min: 384
+      max: 1280
+      multiple_of: 32
+
+  - name: frame_count
+    type: int
+    role: batch_size
+    target: { node: "9", field: "length" }
+    ui:
+      hint: number
+      label: "Frame count"
+      default: 97
+      step: 8
+      required: false
+    validation:
+      min: 9
+      max: 257
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "14", field: "noise_seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: lora
+    type: enum_dynamic
+    role: lora
+    target: { node: "3", field: "lora_name" }
+    options_from: comfyui.loras
+    ui:
+      hint: select
+      label: "LoRA"
+      default: ltx-2.3-22b-distilled-lora-384.safetensors
+      required: false
+
+  - name: lora_strength
+    type: float
+    role: lora_strength
+    target: { node: "3", field: "strength_model" }
+    ui:
+      hint: number
+      label: "LoRA strength"
+      default: 1.0
+      step: 0.1
+      required: false
+    validation:
+      min: 0.0
+      max: 2.0
+
+outputs:
+  - role: output_video
+    node: "17"
+    media: video/mp4
+
+actions: []

--- a/workflows/manifests/ltxv_2_3_22b_t2v.yaml
+++ b/workflows/manifests/ltxv_2_3_22b_t2v.yaml
@@ -1,0 +1,145 @@
+schema_version: 1
+id: ltxv_2_3_22b_t2v
+name: "LTX-Video 2.3 22B (text-to-video)"
+description: |
+  LTX-Video 2.3 22B text-to-video built around the LTXV Q8 distilled LoRA
+  (384-rank) and the Gemma-12B CLIP text encoder. Pipeline:
+  CheckpointLoaderSimple loads the LTX 2.3 22B fp8 checkpoint (model + VAE);
+  LTXAVTextEncoderLoader wires up the Gemma-3-12B text encoder pinned
+  to the LTXV checkpoint (the AV loader is the LTX 2.x successor to
+  LTXVGemmaCLIPModelLoader and is what this server is provisioned for);
+  LoraLoaderModelOnly stacks the distilled 4-8-step LoRA on top of the
+  base model (the Q8 variant in `LTXVQ8LoraModelLoader` is unavailable
+  on this server because the `hadamard_transform` Python dep is not
+  installed - see SLICE_6_RUNS.md); ModelSamplingLTXV adjusts the sigma
+  range; CLIPTextEncode encodes the user's prompt. EmptyLTXVLatentVideo
+  seeds the latent;
+  LTXVScheduler builds the sigma schedule (stretched terminal=0.1);
+  SamplerCustomAdvanced + CFGGuider + KSamplerSelect(euler) + RandomNoise
+  drive the sampling; VAEDecode and VHS_VideoCombine produce the MP4.
+  This manifest is the LTX-Video sibling of wan22_i2v under the shared
+  VideoPlugin - same Modality, same Plugin, different node graph.
+modality: video
+workflow_file: workflows/ltxv_2_3_22b_t2v.json
+
+requires:
+  packs:
+    - custom_nodes.comfyui-videohelpersuite
+  checkpoints:
+    - ltx-2.3-22b-dev-fp8.safetensors
+  clips:
+    - gemma_3_12B_it.safetensors
+  loras:
+    - ltx-2.3-22b-distilled-lora-384.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "6", field: "text" }
+    ui:
+      hint: long_text
+      label: "Prompt"
+      placeholder: "a slow cinematic dolly across a foggy harbor at dawn..."
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "7", field: "text" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: "low quality, blurry, distorted, watermark, static, glitchy"
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: width
+    type: int
+    role: latent_size
+    target: { node: "8", field: "width" }
+    ui:
+      hint: number
+      label: "Width"
+      default: 768
+      step: 32
+      required: false
+    validation:
+      min: 384
+      max: 1280
+      multiple_of: 32
+
+  - name: height
+    type: int
+    role: latent_size
+    target: { node: "8", field: "height" }
+    ui:
+      hint: number
+      label: "Height"
+      default: 512
+      step: 32
+      required: false
+    validation:
+      min: 384
+      max: 1280
+      multiple_of: 32
+
+  - name: frame_count
+    type: int
+    role: batch_size
+    target: { node: "8", field: "length" }
+    ui:
+      hint: number
+      label: "Frame count"
+      default: 97
+      step: 8
+      required: false
+    validation:
+      min: 9
+      max: 257
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "13", field: "noise_seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: lora
+    type: enum_dynamic
+    role: lora
+    target: { node: "3", field: "lora_name" }
+    options_from: comfyui.loras
+    ui:
+      hint: select
+      label: "LoRA"
+      default: ltx-2.3-22b-distilled-lora-384.safetensors
+      required: false
+
+  - name: lora_strength
+    type: float
+    role: lora_strength
+    target: { node: "3", field: "strength_model" }
+    ui:
+      hint: number
+      label: "LoRA strength"
+      default: 1.0
+      step: 0.1
+      required: false
+    validation:
+      min: 0.0
+      max: 2.0
+
+outputs:
+  - role: output_video
+    node: "16"
+    media: video/mp4
+
+actions: []

--- a/workflows/manifests/qwen_image_2512.yaml
+++ b/workflows/manifests/qwen_image_2512.yaml
@@ -124,6 +124,11 @@ actions:
     target_workflow: wan22_i2v
     map:
       - { from_output: output_image, to_slot: init_image }
+  - id: animate_ltx
+    label: "Animate (LTX-Video 2.3)"
+    target_workflow: ltxv_2_3_22b_i2v
+    map:
+      - { from_output: output_image, to_slot: init_image }
   - id: edit
     label: "Edit"
     target_workflow: qwen_edit_2511


### PR DESCRIPTION
Closes #8

## Summary

Adds two new `video`-Modality Manifests for LTX-Video 2.3 22B - text-to-video and image-to-video - and chains the i2v variant from `qwen_image_2512` so a finished Qwen image can be animated end-to-end. Reuses the slice 5 `VideoPlugin` verbatim (no plugin changes).

## Acceptance criteria

- [x] `workflows/ltxv_2_3_22b_t2v.json` - text-to-video graph
- [x] `workflows/ltxv_2_3_22b_i2v.json` - image-to-video graph
- [x] `workflows/manifests/ltxv_2_3_22b_t2v.yaml` (slots: prompt, negative_prompt, width, height, frame_count, seed, lora, lora_strength)
- [x] `workflows/manifests/ltxv_2_3_22b_i2v.yaml` (above + `init_image` at attachment_position 1; chained from `qwen_image_2512`'s `output_image`)
- [x] Reuse `VideoPlugin` - no plugin changes (the slice 5 mapper handles LTX's single `SamplerCustomAdvanced` Progress stream as the degenerate case of its WAN 2.2 dual-stream design)
- [x] Live smoke for both manifests against `http://172.27.1.165:8188` - both `SMOKE OK`
- [x] i2v smoke source image generated by `qwen_image_2512` first
- [x] Unit tests: `tests/test_ltxv_manifest_loading.py` + `tests/test_video_plugin_ltx_compat.py`
- [x] `pytest` passes locally (369 passed, 1 pre-existing skip)
- [x] All filenames in `requires:` resolved live against `/object_info`

## Live smoke evidence

Full transcripts + reasoning in `docs/v3/smoke/SLICE_6_RUNS.md`.

| Manifest | prompt_id | size | latency |
|---|---|---|---|
| `ltxv_2_3_22b_t2v` | `5955945b-0162-4730-b886-99d82c1a42ca` | 384 KB MP4 | 33.04 s |
| `qwen_image_2512` (source for i2v) | `402f9033-617c-4413-8d2d-b39128c974ec` | 3.13 MB PNG | 27.71 s |
| `ltxv_2_3_22b_i2v` | `c043322d-886f-44da-902c-ce978248eb67` | 459 KB MP4 | 42.85 s |

## Plugin change summary

**No plugin changes** - `VideoPlugin` handled LTX-Video 2.3 22B as-is.

- The dual-sampler progress mapper sums per-node `Progress` streams; with one stream it degrades to a clean monotone 0->95% then bumps on post-sample `Executing` (VAEDecode, VHS_VideoCombine) and flips to 100% on `ExecutionComplete`. Covered by `TestSingleSamplerProgressMapping` in `tests/test_video_plugin_ltx_compat.py`.
- The MP4 `render_outputs` path and `validate_slot_values` coercion both work as-is against the LTX manifests' slot shapes (width/height multiple_of=32, frame_count min=9 max=257, dynamic LoRA enum from `comfyui.loras`).

## Server-side notes for follow-up

During live discovery two nodes the slice 6 ticket suggested ("at minimum") turned out to be unusable on this server install (not a workflow bug):

1. `LTXVGemmaCLIPModelLoader` needs a Gemma `tokenizer.model` sentencepiece file that isn't installed. Used `LTXAVTextEncoderLoader` (LTX 2.x successor, loads the same Gemma weights) instead.
2. `LTXVQ8LoraModelLoader` imports `hadamard_transform` which isn't installed. Used plain `LoraLoaderModelOnly` instead - the LTX distilled LoRA is in its option list.
3. `LTXVGemmaEnhancePrompt` raised `min() iterable argument is empty` against the `LTXAVTextEncoderLoader` CLIP. Skipped; the user's prompt feeds straight into `CLIPTextEncode`.

These are *server install* gaps, not architectural choices - documented in `docs/v3/smoke/SLICE_6_RUNS.md` so a follow-up slice can re-enable the LTX-specific loaders once the missing files / Python deps land.

## Anchors

- PRD: §3 Modality coverage (video), §5 Manifests as data
- ADR-0001 (manifest format) - new manifests obey the schema verbatim
- ADR-0002 (modality plugins) - VideoPlugin reused verbatim
- ADR-0003 (slot UI hints) - dynamic LoRA enum via `options_from: comfyui.loras`

## Test plan

- [x] `pytest -q` -> 369 passed, 1 skipped
- [x] `pytest tests/test_ltxv_manifest_loading.py tests/test_video_plugin_ltx_compat.py -q` -> 43 passed
- [x] Live t2v smoke against ComfyUI -> `SMOKE OK`
- [x] Live i2v smoke against ComfyUI with `init_image` uploaded via `_upload_image_slots` -> `SMOKE OK`

## Process

Ran from worktree `/Users/jamievanderpijll/discomfy-slice-6-ltx` (per the slice 6 issue's "workspace isolation" rule); no files modified in the parent `/Users/jamievanderpijll/discomfy` checkout.

Made with [Cursor](https://cursor.com)