### PR TITLE
Slice 3a: image_edit Modality + Qwen-Image-Edit 2511 (1/2/3 images) (closes part of #5)

### DIFF
--- a/core/modalities/__init__.py
+++ b/core/modalities/__init__.py
@@ -17,12 +17,14 @@ from core.modalities.base import (
     SlotValueValidationError,
     SlotValues,
 )
+from core.modalities.image_edit.plugin import ImageEditPlugin
 from core.modalities.image_t2i.plugin import ImageT2IPlugin
 from core.modalities.image_upscale.plugin import ImageUpscalePlugin
 from core.modalities.registry import ModalityRegistry, default_registry
 
 __all__ = [
     "AudioTTSPlugin",
+    "ImageEditPlugin",
     "ImageT2IPlugin",
     "ImageUpscalePlugin",
     "ModalityPlugin",

--- a/core/modalities/image_edit/__init__.py
+++ b/core/modalities/image_edit/__init__.py
@@ -1,0 +1,11 @@
+"""Image-edit Plugin (ADR-0002).
+
+The ``image_edit`` Modality takes between one and three source images
+plus a natural-language edit instruction and produces a single
+``image/png`` output. Different Manifests under this Modality wire
+different numbers of source-image Slots; the Plugin is shared.
+"""
+
+from core.modalities.image_edit.plugin import ImageEditPlugin
+
+__all__ = ["ImageEditPlugin"]

--- a/core/modalities/image_edit/plugin.py
+++ b/core/modalities/image_edit/plugin.py
@@ -1,0 +1,210 @@
+"""Image-edit Plugin (ADR-0002).
+
+Modality contract:
+
+- ``output_media``: ``["image/png"]``. The edit workflows decode a
+  latent into a PNG just like ``image_t2i``; what makes this Modality
+  distinct from ``image_t2i`` is that it takes one or more *existing*
+  images as inputs (via ``TextEncodeQwenImageEditPlus`` for Qwen, or
+  Kontext-style nodes for FLUX Klein in the follow-up slice).
+- Validator: coerces TEXT / INT / FLOAT / SEED / ENUM / IMAGE slots
+  and applies ``slots[].validation`` rules from the Manifest. IMAGE
+  slots carry the ComfyUI input filename (the bot or the smoke harness
+  uploads the local file first and writes the server-side name into
+  the slot value).
+- ProgressMapper: sums ``progress`` events across whichever sampler
+  nodes ComfyUI reports for the active prompt, identical to the
+  ``image_t2i`` mapper. Qwen-Image-Edit-2511 runs a single 4-step
+  KSampler with the Lightning LoRA, so the mapper sees one node.
+- Renderer: builds a Discord embed surfacing the edit instruction,
+  every source filename the Run consumed, the seed, and attaches the
+  decoded PNG.
+- Default actions: respect the Manifest's declared Actions verbatim.
+  Image-edit outputs are valid inputs to upscale and animate Runs;
+  the Manifest decides which buttons to expose so future-Manifest
+  authors stay in control.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.manifest.roles import Modality, Role
+from core.manifest.schema import Action, Manifest
+from core.modalities.base import (
+    ProgressMapper,
+    SlotValues,
+    coerce_slot_values_against_manifest,
+    enforce_validation_rules,
+)
+from core.run import DiscordFile, DiscordPayload, Output, Run
+
+
+class _SteppedProgressMapper:
+    """Sum ``progress`` events across all sampler nodes into one percentage.
+
+    Mirrors the ``image_t2i`` mapper. Qwen-Image-Edit-2511 with the
+    Lightning LoRA samples in 4 steps on a single KSampler so the
+    denominator stays constant once the first event arrives; the same
+    code still handles future edit workflows that chain multiple
+    samplers (e.g. a refiner pass) without any change.
+    """
+
+    def __init__(self) -> None:
+        self._per_node: dict[str, tuple[int, int]] = {}
+        self._last_pct: int | None = None
+        self._complete: bool = False
+
+    def update(self, event: Any) -> int | None:
+        from core.comfyui.v3.ws import (
+            Executing,
+            ExecutionComplete,
+            Progress,
+            Reconnected,
+        )
+
+        if isinstance(event, Reconnected):
+            return self._last_pct
+        if isinstance(event, ExecutionComplete):
+            self._complete = True
+            self._last_pct = 100
+            return 100
+        if isinstance(event, Executing) and event.node is None and event.prompt_id:
+            self._complete = True
+            self._last_pct = 100
+            return 100
+        if not isinstance(event, Progress):
+            return None
+        node = event.node or "_default_"
+        max_steps = max(int(event.max), 1)
+        value = max(0, min(int(event.value), max_steps))
+        self._per_node[node] = (value, max_steps)
+        total_value = sum(v for v, _ in self._per_node.values())
+        total_max = sum(m for _, m in self._per_node.values())
+        if total_max <= 0:
+            return None
+        pct = int((total_value / total_max) * 100)
+        if self._complete:
+            pct = 100
+        if self._last_pct is not None:
+            pct = max(pct, self._last_pct)
+        if pct == self._last_pct:
+            return None
+        self._last_pct = pct
+        return pct
+
+
+class ImageEditPlugin:
+    """Plugin for the ``image_edit`` Modality. ADR-0002 contract."""
+
+    modality: Modality = Modality.IMAGE_EDIT
+    output_media: list[str] = ["image/png"]
+
+    async def validate_slot_values(
+        self, manifest: Manifest, values: SlotValues
+    ) -> SlotValues:
+        coerced = coerce_slot_values_against_manifest(manifest, values)
+        enforce_validation_rules(manifest, coerced)
+        return coerced
+
+    def progress_mapper(self) -> ProgressMapper:
+        return _SteppedProgressMapper()
+
+    async def render_outputs(
+        self, run: Run, outputs: list[Output]
+    ) -> DiscordPayload:
+        images = [o for o in outputs if o.role == Role.OUTPUT_IMAGE]
+        files = [
+            DiscordFile(
+                filename=o.filename,
+                content_type=o.media,
+                data=o.bytes_read,
+            )
+            for o in images
+        ]
+        fields: list[dict[str, Any]] = []
+        prompt = run.slot_values.get("prompt")
+        if prompt:
+            fields.append(
+                {
+                    "name": "Instruction",
+                    "value": _truncate(str(prompt), 1024),
+                    "inline": False,
+                }
+            )
+        negative = run.slot_values.get("negative_prompt")
+        if negative:
+            fields.append(
+                {
+                    "name": "Negative",
+                    "value": _truncate(str(negative), 1024),
+                    "inline": False,
+                }
+            )
+        sources = _collect_source_image_slot_values(run)
+        if sources:
+            fields.append(
+                {
+                    "name": "Sources",
+                    "value": _truncate("\n".join(sources), 1024),
+                    "inline": False,
+                }
+            )
+        seed = run.slot_values.get("seed")
+        if seed is not None:
+            fields.append({"name": "Seed", "value": str(seed), "inline": True})
+        lora = run.slot_values.get("lora")
+        if lora:
+            fields.append({"name": "LoRA", "value": str(lora), "inline": True})
+        if images:
+            fields.append(
+                {
+                    "name": "Output",
+                    "value": (
+                        f"{images[0].filename} "
+                        f"({images[0].size_bytes:,} bytes)"
+                    ),
+                    "inline": False,
+                }
+            )
+        embed: dict[str, Any] = {
+            "title": run.manifest_id,
+            "color": 0xEB459E,
+            "fields": fields,
+            "footer": {
+                "text": f"prompt_id: {run.prompt_id}" if run.prompt_id else ""
+            },
+        }
+        if images:
+            embed["image"] = {"url": f"attachment://{images[0].filename}"}
+        return DiscordPayload(embed=embed, files=files)
+
+    def default_post_actions(self, manifest: Manifest) -> list[Action]:
+        return list(manifest.actions)
+
+
+def _collect_source_image_slot_values(run: Run) -> list[str]:
+    """Fallback: pick image_1/image_2/image_3 from slot_values by name.
+
+    Used when the renderer has no Manifest handle. Sorted by suffix so
+    output is stable regardless of dict iteration order.
+    """
+    out: list[tuple[str, str]] = []
+    for name, value in run.slot_values.items():
+        if not value:
+            continue
+        if name == "image_1" or name == "image":
+            out.append((name, str(value)))
+        elif name.startswith("image_") and name[6:].isdigit():
+            out.append((name, str(value)))
+    out.sort(key=lambda pair: pair[0])
+    return [v for _, v in out]
+
+
+def _truncate(s: str, limit: int) -> str:
+    if len(s) <= limit:
+        return s
+    return s[: limit - 1] + "\u2026"
+
+
+__all__ = ["ImageEditPlugin"]

--- a/core/modalities/registry.py
+++ b/core/modalities/registry.py
@@ -55,12 +55,14 @@ def _wire_default_plugins() -> None:
     this function.
     """
     from core.modalities.audio_tts.plugin import AudioTTSPlugin
+    from core.modalities.image_edit.plugin import ImageEditPlugin
     from core.modalities.image_t2i.plugin import ImageT2IPlugin
     from core.modalities.image_upscale.plugin import ImageUpscalePlugin
     from core.modalities.video.plugin import VideoPlugin
 
     default_registry.register(ImageT2IPlugin())
     default_registry.register(ImageUpscalePlugin())
+    default_registry.register(ImageEditPlugin())
     default_registry.register(VideoPlugin())
     default_registry.register(AudioTTSPlugin())
 

--- a/docs/v3/smoke/SLICE_3_RUNS.md
+++ b/docs/v3/smoke/SLICE_3_RUNS.md
@@ -1,0 +1,128 @@
+# Slice 3a (issue #5) - image_edit smoke runs (Qwen-Image-Edit 2511)
+
+**Branch:** `slice/5-qwen-edit`
+**Modality:** `image_edit`
+**Manifests under test:**
+- `qwen_image_edit_2511_1image` (`workflows/qwen_image_edit_2511_1image.json`)
+- `qwen_image_edit_2511_2images` (`workflows/qwen_image_edit_2511_2images.json`)
+- `qwen_image_edit_2511_3images` (`workflows/qwen_image_edit_2511_3images.json`)
+
+**ComfyUI target:** `http://172.27.1.165:8188` (RTX 5090, fp8 mixed UNET)
+
+**Models discovered from `/object_info`:**
+- UNET: `qwen_image_edit_2511_fp8mixed.safetensors`
+- CLIP: `qwen_2.5_vl_7b_fp8_scaled.safetensors` (`type: qwen_image`)
+- VAE: `qwen_image_vae.safetensors`
+- Lightning LoRA (baked at node 4, strength 1.0):
+  `Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors`
+- User LoRA default (node 5, strength 0.0 by default):
+  `QWEN_EDIT_ACTION_V1.safetensors`
+
+**Scope note:** Slice 3 (#5) also covers FLUX Kontext on Klein. That
+half is **deferred to a follow-up issue / PR** because the Klein
+workflow is gated on Slice 2 fixing FLUX 2 Klein first. Issue #5 stays
+open after Slice 3a merges; the follow-up PR will close it.
+
+## Status: PASSED
+
+All three variants ran end-to-end against the live ComfyUI on
+2026-06-02 and produced a decoded PNG within the expected ~20s
+latency budget for the 4-step Lightning LoRA.
+
+### Source images (generated via `qwen_image_2512` first)
+
+| purpose | prompt_id | local file |
+| --- | --- | --- |
+| red panda (subject) | `7f774e28-3c96-4fda-8b39-b85e4fe84318` | `output/v3_smoke/7f774e28-.../final_output_00007_.png` |
+| leather armchair (scene)  | `2419e6ff-e25c-4a61-b6c0-49b064490763` | `output/v3_smoke/2419e6ff-.../final_output_00009_.png` |
+| parrot (color reference) | `003693d4-8de8-44e4-9578-e4af52b0cd3a` | `output/v3_smoke/003693d4-.../final_output_00010_.png` |
+
+### 1-image variant
+
+| field | value |
+| --- | --- |
+| manifest | `qwen_image_edit_2511_1image` |
+| prompt | "add a small wooden cabin in the background, with smoke rising from its chimney" |
+| inputs | `image_1` = red panda |
+| prompt_id | `f46e87b3-19a8-41f6-8a97-d5aa5cf9aaf2` |
+| latency | 21.77 s |
+| output bytes | 2,333,633 |
+| output | `qwen_edit_2511_00001_.png` |
+
+### 2-image variant
+
+| field | value |
+| --- | --- |
+| manifest | `qwen_image_edit_2511_2images` |
+| prompt | "Place the red panda from image 1 sitting on top of the leather armchair from image 2" |
+| inputs | `image_1` = red panda, `image_2` = armchair |
+| prompt_id | `8f1e061c-2526-408a-aa81-77ce8b4865da` |
+| latency | 17.14 s |
+| output bytes | 1,896,280 |
+| output | `qwen_edit_2511_00002_.png` |
+
+### 3-image variant
+
+| field | value |
+| --- | --- |
+| manifest | `qwen_image_edit_2511_3images` |
+| prompt | "The red panda from image 1 wearing the colors of the parrot from image 3, sitting on the armchair from image 2" |
+| inputs | `image_1` = red panda, `image_2` = armchair, `image_3` = parrot |
+| prompt_id | `eeb3bf7a-1747-4750-8f87-5a1c0e2d5d14` |
+| latency | 20.47 s |
+| output bytes | 2,139,755 |
+| output | `qwen_edit_2511_00003_.png` |
+
+## Reproducing the smokes
+
+```bash
+source venv/bin/activate
+
+# 1) generate a fresh source image via the t2i manifest
+python scripts/v3_smoke.py \
+  --manifest qwen_image_2512 \
+  --slot prompt="a single red panda eating bamboo in a forest clearing" \
+  --slot width=1024 --slot height=1024 --slot lora_strength=0.0
+# note the output path it prints, then use it below as --slot image_1=...
+
+# 2) 1-image edit
+python scripts/v3_smoke.py \
+  --manifest qwen_image_edit_2511_1image \
+  --slot prompt="add a small wooden cabin in the background" \
+  --slot image_1=/path/from/step/1.png \
+  --slot lora_strength=0.0
+
+# 3) 2-image edit (generate a second source the same way first)
+python scripts/v3_smoke.py \
+  --manifest qwen_image_edit_2511_2images \
+  --slot prompt="Place the subject from image 1 onto the scene from image 2" \
+  --slot image_1=/path/to/subject.png \
+  --slot image_2=/path/to/scene.png \
+  --slot lora_strength=0.0
+
+# 4) 3-image edit
+python scripts/v3_smoke.py \
+  --manifest qwen_image_edit_2511_3images \
+  --slot prompt="subject of image 1, attire from image 2, scene from image 3" \
+  --slot image_1=/path/to/subject.png \
+  --slot image_2=/path/to/attire.png \
+  --slot image_3=/path/to/scene.png \
+  --slot lora_strength=0.0
+```
+
+## Notes on the graph
+
+- Each variant shares nodes 1-15 (loaders + Lightning LoRA + user
+  LoRA stack + `ModelSamplingAuraFlow` + `CFGNorm` + first `LoadImage`
+  + `ImageScaleToTotalPixels` to ~1.5 MP + `VAEEncode` + the two
+  `TextEncodeQwenImageEditPlus` conditioning nodes + `KSampler` +
+  `VAEDecode` + `SaveImage`).
+- The 2-image variant adds node `16` (`LoadImage`); the 3-image
+  variant adds nodes `16` and `17`. Extra source images are wired
+  directly into `image2`/`image3` of nodes `11` (negative) and `12`
+  (positive) without re-scaling, matching the reference flow ComfyUI's
+  `TextEncodeQwenImageEditPlus` author has shipped.
+- The user LoRA at node 5 defaults to strength `0.0` so the manifest
+  is safe to register on any server with the declared LoRA filename
+  installed; users can opt in to a Qwen-Edit LoRA via the slot's
+  `select` UI.

--- a/tests/test_image_edit_plugin.py
+++ b/tests/test_image_edit_plugin.py
@@ -1,0 +1,302 @@
+"""Tests for the image_edit Plugin (ADR-0002, Slice 3a).
+
+Seams under test:
+
+- Plugin contract surface (``modality`` / ``output_media``).
+- ``validate_slot_values`` coerces raw user input to canonical types
+  (IMAGE slots pass through as strings; TEXT/SEED/ENUM/FLOAT coerce
+  and validation rules fire), and rejects unknown slots / out-of-range
+  numbers.
+- ``progress_mapper`` reaches 100 on ``ExecutionComplete`` and on the
+  closing ``executing(node=None)`` event, and is monotone.
+- ``render_outputs`` builds an embed that surfaces the edit
+  instruction, the seed, every source-image filename, and attaches the
+  output PNG.
+- ``default_post_actions`` echoes the Manifest's declared Actions (the
+  image_edit Modality is a legitimate chain point - "Upscale this
+  edit" and "Animate this edit" are valid follow-ups).
+- The Plugin is registered in :data:`core.modalities.default_registry`
+  for :class:`Modality.IMAGE_EDIT`.
+
+No live ComfyUI; no Discord runtime.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from core.comfyui.v3.ws import (
+    Executing,
+    ExecutionComplete,
+    Progress,
+    Reconnected,
+)
+from core.manifest import load_manifest
+from core.manifest.roles import Modality, Role
+from core.manifest.schema import Action, ActionMap
+from core.modalities import default_registry
+from core.modalities.base import SlotValueValidationError
+from core.modalities.image_edit.plugin import ImageEditPlugin
+from core.run import Output, Run, RunStatus
+
+
+@pytest.fixture
+def manifest_1():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_1image.yaml")
+
+
+@pytest.fixture
+def manifest_2():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_2images.yaml")
+
+
+@pytest.fixture
+def manifest_3():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_3images.yaml")
+
+
+@pytest.fixture
+def plugin() -> ImageEditPlugin:
+    return ImageEditPlugin()
+
+
+class TestPluginContract:
+    def test_modality(self, plugin: ImageEditPlugin) -> None:
+        assert plugin.modality == Modality.IMAGE_EDIT
+
+    def test_output_media_is_png(self, plugin: ImageEditPlugin) -> None:
+        assert plugin.output_media == ["image/png"]
+
+    def test_registered_in_default_registry(self) -> None:
+        registered = default_registry.get(Modality.IMAGE_EDIT)
+        assert isinstance(registered, ImageEditPlugin)
+
+
+class TestValidateSlotValues:
+    @pytest.mark.asyncio
+    async def test_coerces_seed_and_passes_image(self, plugin, manifest_1):
+        out = await plugin.validate_slot_values(
+            manifest_1,
+            {
+                "prompt": "make the sky red",
+                "image_1": "uploaded_source.png",
+                "seed": "12345",
+                "lora_strength": "0.5",
+            },
+        )
+        assert out["prompt"] == "make the sky red"
+        assert out["image_1"] == "uploaded_source.png"
+        assert out["seed"] == 12345
+        assert isinstance(out["lora_strength"], float)
+        assert out["lora_strength"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_seed_random_string(self, plugin, manifest_1):
+        out = await plugin.validate_slot_values(
+            manifest_1,
+            {
+                "prompt": "x",
+                "image_1": "a.png",
+                "seed": "random",
+            },
+        )
+        assert isinstance(out["seed"], int)
+        assert 0 <= out["seed"] < 2**63
+
+    @pytest.mark.asyncio
+    async def test_empty_prompt_rejected(self, plugin, manifest_1):
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest_1,
+                {
+                    "prompt": "",
+                    "image_1": "a.png",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_lora_strength_above_max_rejected(self, plugin, manifest_1):
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest_1,
+                {
+                    "prompt": "x",
+                    "image_1": "a.png",
+                    "lora_strength": "5.0",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_slot_rejected(self, plugin, manifest_1):
+        with pytest.raises(SlotValueValidationError):
+            await plugin.validate_slot_values(
+                manifest_1,
+                {
+                    "prompt": "x",
+                    "image_1": "a.png",
+                    "nope": "anything",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_two_image_manifest_accepts_both_sources(
+        self, plugin, manifest_2
+    ):
+        out = await plugin.validate_slot_values(
+            manifest_2,
+            {
+                "prompt": "compose",
+                "image_1": "a.png",
+                "image_2": "b.png",
+            },
+        )
+        assert out["image_1"] == "a.png"
+        assert out["image_2"] == "b.png"
+
+    @pytest.mark.asyncio
+    async def test_three_image_manifest_accepts_all_sources(
+        self, plugin, manifest_3
+    ):
+        out = await plugin.validate_slot_values(
+            manifest_3,
+            {
+                "prompt": "compose",
+                "image_1": "a.png",
+                "image_2": "b.png",
+                "image_3": "c.png",
+            },
+        )
+        assert out["image_1"] == "a.png"
+        assert out["image_2"] == "b.png"
+        assert out["image_3"] == "c.png"
+
+
+class TestProgressMapper:
+    def test_reconnected_returns_none_initially(self, plugin):
+        mapper = plugin.progress_mapper()
+        assert mapper.update(Reconnected()) is None
+
+    def test_execution_complete_jumps_to_100(self, plugin):
+        mapper = plugin.progress_mapper()
+        assert mapper.update(ExecutionComplete(prompt_id="x")) == 100
+
+    def test_executing_null_node_means_done(self, plugin):
+        mapper = plugin.progress_mapper()
+        assert mapper.update(Executing(node=None, prompt_id="x")) == 100
+
+    def test_progress_events_are_monotone(self, plugin):
+        mapper = plugin.progress_mapper()
+        seq = []
+        for v in range(1, 5):
+            seq.append(mapper.update(Progress(node="13", value=v, max=4)))
+        filtered = [s for s in seq if s is not None]
+        assert filtered == sorted(filtered)
+        assert filtered[-1] == 100
+
+
+class TestRenderOutputs:
+    @pytest.mark.asyncio
+    async def test_renders_instruction_seed_sources_and_attachment(
+        self, plugin, manifest_1, tmp_path: Path
+    ):
+        png_bytes = b"\x89PNG\r\n\x1a\nedited-pixels"
+        out_path = tmp_path / "qwen_edit_2511_00001_.png"
+        out_path.write_bytes(png_bytes)
+        run = Run(
+            id=uuid.uuid4().hex,
+            manifest_id=manifest_1.id,
+            prompt_id="prompt-xyz",
+            slot_values={
+                "prompt": "Replace the background with a snowy mountain",
+                "negative_prompt": "blurry, low-res",
+                "image_1": "source_in.png",
+                "seed": 4242,
+                "lora": "QWEN_EDIT_ACTION_V1.safetensors",
+                "lora_strength": 0.0,
+            },
+            status=RunStatus.COMPLETE,
+        )
+        output = Output(
+            role=Role.OUTPUT_IMAGE,
+            media="image/png",
+            path=out_path,
+            bytes_read=png_bytes,
+        )
+        payload = await plugin.render_outputs(run, [output])
+        assert payload.embed["title"] == manifest_1.id
+        names = [f["name"] for f in payload.embed["fields"]]
+        assert "Instruction" in names
+        assert "Negative" in names
+        assert "Sources" in names
+        assert "Seed" in names
+        assert "Output" in names
+        assert len(payload.files) == 1
+        assert payload.files[0].filename == "qwen_edit_2511_00001_.png"
+        assert payload.embed["image"]["url"] == (
+            "attachment://qwen_edit_2511_00001_.png"
+        )
+
+    @pytest.mark.asyncio
+    async def test_renders_all_three_sources_in_order(
+        self, plugin, manifest_3, tmp_path: Path
+    ):
+        png_bytes = b"x"
+        out_path = tmp_path / "edit3.png"
+        out_path.write_bytes(png_bytes)
+        run = Run(
+            id="r",
+            manifest_id=manifest_3.id,
+            slot_values={
+                "prompt": "compose them",
+                "image_1": "subject.png",
+                "image_2": "outfit.png",
+                "image_3": "scene.png",
+            },
+        )
+        output = Output(
+            role=Role.OUTPUT_IMAGE,
+            media="image/png",
+            path=out_path,
+            bytes_read=png_bytes,
+        )
+        payload = await plugin.render_outputs(run, [output])
+        sources_field = next(
+            f for f in payload.embed["fields"] if f["name"] == "Sources"
+        )
+        assert "subject.png" in sources_field["value"]
+        assert "outfit.png" in sources_field["value"]
+        assert "scene.png" in sources_field["value"]
+        idx_sub = sources_field["value"].index("subject.png")
+        idx_out = sources_field["value"].index("outfit.png")
+        idx_sce = sources_field["value"].index("scene.png")
+        assert idx_sub < idx_out < idx_sce
+
+    @pytest.mark.asyncio
+    async def test_no_outputs_yields_no_files(self, plugin, manifest_1):
+        run = Run(id="x", manifest_id=manifest_1.id)
+        payload = await plugin.render_outputs(run, [])
+        assert payload.files == []
+        assert "image" not in payload.embed
+
+
+class TestDefaultPostActions:
+    def test_returns_manifest_actions(self, plugin, manifest_1):
+        actions = plugin.default_post_actions(manifest_1)
+        ids = {a.id for a in actions}
+        assert "upscale" in ids
+        assert "animate" in ids
+
+    def test_returns_a_new_list_not_shared(self, plugin, manifest_1):
+        returned = plugin.default_post_actions(manifest_1)
+        returned.append(
+            Action(
+                id="extra",
+                label="x",
+                target_workflow="image_upscale_latent",
+                map=[ActionMap(from_output=Role.OUTPUT_IMAGE, to_slot="source_image")],
+            )
+        )
+        assert "extra" not in {a.id for a in manifest_1.actions}

--- a/tests/test_qwen_edit_manifest_loading.py
+++ b/tests/test_qwen_edit_manifest_loading.py
@@ -1,0 +1,357 @@
+"""Tests for the three Qwen-Image-Edit 2511 manifests (Slice 3a).
+
+Each manifest must:
+
+- Load without schema errors and expose the expected ``id`` and
+  :class:`Modality.IMAGE_EDIT`.
+- Declare exact filenames in ``requires`` (UNET / VAE / CLIP / LoRAs)
+  that match what ``/object_info`` would advertise on a server with
+  Qwen-Image-Edit-2511 installed.
+- Validate against a hand-built ``Inventory`` that supplies those
+  exact filenames (positive path) and fail validation when any of the
+  required filenames is absent (negative path).
+- Cover every slot's manifest target with a node that exists in the
+  workflow JSON (no orphans).
+- Apply cleanly via :func:`core.manifest.apply_slots` with a
+  representative slot-values dict, exercising the user-facing image
+  slot wiring for 1/2/3 inputs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.comfyui.v3.capability import Inventory
+from core.manifest import apply_slots, load_manifest, load_manifest_directory
+from core.manifest.roles import Modality
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+QWEN_EDIT_UNET = "qwen_image_edit_2511_fp8mixed.safetensors"
+QWEN_VAE = "qwen_image_vae.safetensors"
+QWEN_CLIP = "qwen_2.5_vl_7b_fp8_scaled.safetensors"
+QWEN_LIGHTNING_LORA = (
+    "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors"
+)
+QWEN_USER_LORA = "QWEN_EDIT_ACTION_V1.safetensors"
+
+
+@pytest.fixture
+def manifest_1():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_1image.yaml")
+
+
+@pytest.fixture
+def manifest_2():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_2images.yaml")
+
+
+@pytest.fixture
+def manifest_3():
+    return load_manifest("workflows/manifests/qwen_image_edit_2511_3images.yaml")
+
+
+def _inventory_with_all() -> Inventory:
+    """Build an Inventory shaped like a server with everything installed."""
+    object_info: dict[str, Any] = {
+        "UNETLoader": {
+            "input": {
+                "required": {
+                    "unet_name": [[QWEN_EDIT_UNET, "other.safetensors"], {}],
+                }
+            },
+            "python_module": "nodes",
+        },
+        "VAELoader": {
+            "input": {
+                "required": {
+                    "vae_name": [[QWEN_VAE], {}],
+                }
+            },
+            "python_module": "nodes",
+        },
+        "CLIPLoader": {
+            "input": {
+                "required": {
+                    "clip_name": [[QWEN_CLIP], {}],
+                }
+            },
+            "python_module": "nodes",
+        },
+        "LoraLoaderModelOnly": {
+            "input": {
+                "required": {
+                    "lora_name": [[QWEN_LIGHTNING_LORA, QWEN_USER_LORA], {}],
+                }
+            },
+            "python_module": "nodes",
+        },
+    }
+    return Inventory(object_info)
+
+
+def _inventory_without(*, drop_lora: str | None = None, drop_unet: bool = False) -> Inventory:
+    object_info: dict[str, Any] = {
+        "UNETLoader": {
+            "input": {
+                "required": {
+                    "unet_name": [
+                        ["other.safetensors"]
+                        if drop_unet
+                        else [QWEN_EDIT_UNET],
+                        {},
+                    ],
+                }
+            },
+            "python_module": "nodes",
+        },
+        "VAELoader": {
+            "input": {
+                "required": {"vae_name": [[QWEN_VAE], {}]},
+            },
+            "python_module": "nodes",
+        },
+        "CLIPLoader": {
+            "input": {
+                "required": {"clip_name": [[QWEN_CLIP], {}]},
+            },
+            "python_module": "nodes",
+        },
+        "LoraLoaderModelOnly": {
+            "input": {
+                "required": {
+                    "lora_name": [
+                        [
+                            lora
+                            for lora in (QWEN_LIGHTNING_LORA, QWEN_USER_LORA)
+                            if lora != drop_lora
+                        ],
+                        {},
+                    ],
+                }
+            },
+            "python_module": "nodes",
+        },
+    }
+    return Inventory(object_info)
+
+
+class TestManifestLoading:
+    @pytest.mark.parametrize(
+        "fixture_name,expected_id",
+        [
+            ("manifest_1", "qwen_image_edit_2511_1image"),
+            ("manifest_2", "qwen_image_edit_2511_2images"),
+            ("manifest_3", "qwen_image_edit_2511_3images"),
+        ],
+    )
+    def test_loads_with_expected_id_and_modality(
+        self, request, fixture_name: str, expected_id: str
+    ) -> None:
+        m = request.getfixturevalue(fixture_name)
+        assert m.id == expected_id
+        assert m.modality == Modality.IMAGE_EDIT
+
+    def test_directory_load_includes_all_three(self) -> None:
+        loaded, errors = load_manifest_directory("workflows/manifests")
+        ids = {m.id for m in loaded}
+        assert "qwen_image_edit_2511_1image" in ids
+        assert "qwen_image_edit_2511_2images" in ids
+        assert "qwen_image_edit_2511_3images" in ids
+        assert not errors, f"unexpected manifest load errors: {errors}"
+
+
+class TestRequiresValidation:
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["manifest_1", "manifest_2", "manifest_3"],
+    )
+    def test_satisfied_with_full_inventory(
+        self, request, fixture_name: str
+    ) -> None:
+        m = request.getfixturevalue(fixture_name)
+        inv = _inventory_with_all()
+        assert inv.validate_requires(m.requires) == []
+
+    def test_unet_missing_disables(self, manifest_1) -> None:
+        inv = _inventory_without(drop_unet=True)
+        problems = inv.validate_requires(manifest_1.requires)
+        assert problems
+        assert any(QWEN_EDIT_UNET in p for p in problems)
+
+    def test_lightning_lora_missing_disables(self, manifest_2) -> None:
+        inv = _inventory_without(drop_lora=QWEN_LIGHTNING_LORA)
+        problems = inv.validate_requires(manifest_2.requires)
+        assert problems
+        assert any(QWEN_LIGHTNING_LORA in p for p in problems)
+
+
+class TestNodeMapCoversWorkflow:
+    """Every Slot target must point at a node in the workflow JSON."""
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["manifest_1", "manifest_2", "manifest_3"],
+    )
+    def test_every_slot_target_resolves(
+        self, request, fixture_name: str
+    ) -> None:
+        m = request.getfixturevalue(fixture_name)
+        workflow_path = REPO_ROOT / m.workflow_file
+        workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+        for slot in m.slots:
+            for target in slot.resolved_targets():
+                assert target.node in workflow, (
+                    f"slot '{slot.name}' targets missing node "
+                    f"'{target.node}' in {m.id}"
+                )
+                inputs = workflow[target.node]["inputs"]
+                assert target.field in inputs, (
+                    f"slot '{slot.name}' targets missing field "
+                    f"'{target.field}' on node '{target.node}' in {m.id}"
+                )
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["manifest_1", "manifest_2", "manifest_3"],
+    )
+    def test_every_output_node_exists(
+        self, request, fixture_name: str
+    ) -> None:
+        m = request.getfixturevalue(fixture_name)
+        workflow_path = REPO_ROOT / m.workflow_file
+        workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+        for spec in m.outputs:
+            assert spec.node in workflow, (
+                f"output node '{spec.node}' missing from {m.id}'s workflow"
+            )
+
+
+class TestSlotCounts:
+    def test_1image_has_one_image_slot(self, manifest_1) -> None:
+        image_slots = [s for s in manifest_1.slots if s.type.value == "image"]
+        assert len(image_slots) == 1
+        assert image_slots[0].name == "image_1"
+
+    def test_2image_has_two_image_slots(self, manifest_2) -> None:
+        image_slots = [s for s in manifest_2.slots if s.type.value == "image"]
+        names = {s.name for s in image_slots}
+        assert names == {"image_1", "image_2"}
+
+    def test_3image_has_three_image_slots(self, manifest_3) -> None:
+        image_slots = [s for s in manifest_3.slots if s.type.value == "image"]
+        names = {s.name for s in image_slots}
+        assert names == {"image_1", "image_2", "image_3"}
+
+    def test_attachment_positions_are_1_indexed_and_unique(
+        self, manifest_3
+    ) -> None:
+        positions = sorted(
+            s.ui.attachment_position
+            for s in manifest_3.slots
+            if s.ui.attachment_position is not None
+        )
+        assert positions == [1, 2, 3]
+
+
+class TestApplySlots:
+    def test_one_image_apply_writes_through(self, manifest_1) -> None:
+        workflow = json.loads(
+            (REPO_ROOT / manifest_1.workflow_file).read_text("utf-8")
+        )
+        out = apply_slots(
+            workflow,
+            manifest_1,
+            {
+                "prompt": "make the sky red",
+                "negative_prompt": "blurry",
+                "image_1": "src.png",
+                "seed": 42,
+                "lora": QWEN_USER_LORA,
+                "lora_strength": 0.0,
+            },
+        )
+        assert out["12"]["inputs"]["prompt"] == "make the sky red"
+        assert out["11"]["inputs"]["prompt"] == "blurry"
+        assert out["8"]["inputs"]["image"] == "src.png"
+        assert out["13"]["inputs"]["seed"] == 42
+        assert out["5"]["inputs"]["lora_name"] == QWEN_USER_LORA
+        assert out["5"]["inputs"]["strength_model"] == 0.0
+
+    def test_two_image_apply_wires_both_sources(self, manifest_2) -> None:
+        workflow = json.loads(
+            (REPO_ROOT / manifest_2.workflow_file).read_text("utf-8")
+        )
+        out = apply_slots(
+            workflow,
+            manifest_2,
+            {
+                "prompt": "compose",
+                "image_1": "a.png",
+                "image_2": "b.png",
+            },
+        )
+        assert out["8"]["inputs"]["image"] == "a.png"
+        assert out["16"]["inputs"]["image"] == "b.png"
+        assert out["11"]["inputs"]["image2"] == ["16", 0]
+        assert out["12"]["inputs"]["image2"] == ["16", 0]
+
+    def test_three_image_apply_wires_all_sources(self, manifest_3) -> None:
+        workflow = json.loads(
+            (REPO_ROOT / manifest_3.workflow_file).read_text("utf-8")
+        )
+        out = apply_slots(
+            workflow,
+            manifest_3,
+            {
+                "prompt": "compose",
+                "image_1": "a.png",
+                "image_2": "b.png",
+                "image_3": "c.png",
+            },
+        )
+        assert out["8"]["inputs"]["image"] == "a.png"
+        assert out["16"]["inputs"]["image"] == "b.png"
+        assert out["17"]["inputs"]["image"] == "c.png"
+        assert out["11"]["inputs"]["image3"] == ["17", 0]
+        assert out["12"]["inputs"]["image3"] == ["17", 0]
+
+
+class TestRequiredFilenamesArePopulated:
+    """Workflow JSON loader fields must contain the exact required filenames.
+
+    Mirrors the "no model branching" rule: a manifest's ``requires``
+    list and the workflow JSON's loader inputs must agree.
+    """
+
+    @pytest.mark.parametrize(
+        "fixture_name",
+        ["manifest_1", "manifest_2", "manifest_3"],
+    )
+    def test_unet_clip_vae_lora_names_match_requires(
+        self, request, fixture_name: str
+    ) -> None:
+        m = request.getfixturevalue(fixture_name)
+        workflow = json.loads(
+            (REPO_ROOT / m.workflow_file).read_text("utf-8")
+        )
+        loader_filenames: set[str] = set()
+        for node in workflow.values():
+            inputs = node.get("inputs", {})
+            for key in ("unet_name", "clip_name", "vae_name", "lora_name"):
+                if key in inputs and isinstance(inputs[key], str):
+                    loader_filenames.add(inputs[key])
+        declared = (
+            set(m.requires.unets)
+            | set(m.requires.vaes)
+            | set(m.requires.clips)
+            | set(m.requires.loras)
+        )
+        assert loader_filenames <= declared, (
+            f"workflow uses filenames not in requires: "
+            f"{loader_filenames - declared}"
+        )

--- a/workflows/manifests/qwen_image_edit_2511_1image.yaml
+++ b/workflows/manifests/qwen_image_edit_2511_1image.yaml
@@ -1,0 +1,120 @@
+schema_version: 1
+id: qwen_image_edit_2511_1image
+name: "Qwen-Image-Edit 2511 (1 image)"
+description: |
+  Qwen-Image-Edit 2511 with the 4-step Lightning LoRA for fast (~10s)
+  natural-language edits on a single source image. The graph wires
+  ``UNETLoader`` -> ``LoraLoaderModelOnly`` (Lightning) ->
+  ``LoraLoaderModelOnly`` (user-stack, default strength 0) ->
+  ``ModelSamplingAuraFlow`` -> ``CFGNorm`` -> ``KSampler`` (euler /
+  simple, 4 steps, cfg=1). ``LoadImage`` -> ``ImageScaleToTotalPixels``
+  (1.5 MP, lanczos) feeds both ``VAEEncode`` (for the KSampler's
+  latent) and the ``image1`` input of two ``TextEncodeQwenImageEditPlus``
+  nodes (positive instruction + empty negative). ``VAEDecode`` ->
+  ``SaveImage`` emits one PNG.
+modality: image_edit
+workflow_file: workflows/qwen_image_edit_2511_1image.json
+
+requires:
+  unets:
+    - qwen_image_edit_2511_fp8mixed.safetensors
+  vaes:
+    - qwen_image_vae.safetensors
+  clips:
+    - qwen_2.5_vl_7b_fp8_scaled.safetensors
+  loras:
+    - Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors
+    - QWEN_EDIT_ACTION_V1.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "12", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Edit instruction"
+      placeholder: "Replace the background with a snowy mountain at sunset"
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "11", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: ""
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: image_1
+    type: image
+    role: source_image
+    target: { node: "8", field: "image" }
+    ui:
+      hint: image
+      label: "Source image"
+      attachment_position: 1
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "13", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: lora
+    type: enum_dynamic
+    role: lora
+    target: { node: "5", field: "lora_name" }
+    options_from: comfyui.loras
+    ui:
+      hint: select
+      label: "User LoRA"
+      default: QWEN_EDIT_ACTION_V1.safetensors
+      required: false
+
+  - name: lora_strength
+    type: float
+    role: lora_strength
+    target: { node: "5", field: "strength_model" }
+    ui:
+      hint: number
+      label: "User LoRA strength"
+      default: 0.0
+      step: 0.1
+      required: false
+    validation:
+      min: 0.0
+      max: 2.0
+
+outputs:
+  - role: output_image
+    node: "15"
+    media: image/png
+
+actions:
+  - id: upscale
+    label: "Upscale 2x"
+    target_workflow: image_upscale_latent
+    map:
+      - { from_output: output_image, to_slot: source_image }
+  - id: animate
+    label: "Animate"
+    target_workflow: wan22_i2v
+    map:
+      - { from_output: output_image, to_slot: init_image }

--- a/workflows/manifests/qwen_image_edit_2511_2images.yaml
+++ b/workflows/manifests/qwen_image_edit_2511_2images.yaml
@@ -1,0 +1,132 @@
+schema_version: 1
+id: qwen_image_edit_2511_2images
+name: "Qwen-Image-Edit 2511 (2 images)"
+description: |
+  Qwen-Image-Edit 2511 4-step Lightning, two-image variant. Same graph
+  as the 1-image manifest plus a second ``LoadImage`` node whose pixels
+  are fed directly to ``image2`` of the positive and negative
+  ``TextEncodeQwenImageEditPlus`` nodes. The first image is still the
+  one driving ``VAEEncode`` (and therefore the KSampler's latent); the
+  second image acts purely as a reference for the edit instruction
+  (e.g. "place the man from image 1 inside the room from image 2").
+modality: image_edit
+workflow_file: workflows/qwen_image_edit_2511_2images.json
+
+requires:
+  unets:
+    - qwen_image_edit_2511_fp8mixed.safetensors
+  vaes:
+    - qwen_image_vae.safetensors
+  clips:
+    - qwen_2.5_vl_7b_fp8_scaled.safetensors
+  loras:
+    - Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors
+    - QWEN_EDIT_ACTION_V1.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "12", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Edit instruction"
+      placeholder: "Place the subject from image 1 into the scene from image 2"
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "11", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: ""
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: image_1
+    type: image
+    role: source_image
+    target: { node: "8", field: "image" }
+    ui:
+      hint: image
+      label: "Source image 1 (primary)"
+      attachment_position: 1
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: image_2
+    type: image
+    role: source_image_2
+    target: { node: "16", field: "image" }
+    ui:
+      hint: image
+      label: "Source image 2 (reference)"
+      attachment_position: 2
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "13", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: lora
+    type: enum_dynamic
+    role: lora
+    target: { node: "5", field: "lora_name" }
+    options_from: comfyui.loras
+    ui:
+      hint: select
+      label: "User LoRA"
+      default: QWEN_EDIT_ACTION_V1.safetensors
+      required: false
+
+  - name: lora_strength
+    type: float
+    role: lora_strength
+    target: { node: "5", field: "strength_model" }
+    ui:
+      hint: number
+      label: "User LoRA strength"
+      default: 0.0
+      step: 0.1
+      required: false
+    validation:
+      min: 0.0
+      max: 2.0
+
+outputs:
+  - role: output_image
+    node: "15"
+    media: image/png
+
+actions:
+  - id: upscale
+    label: "Upscale 2x"
+    target_workflow: image_upscale_latent
+    map:
+      - { from_output: output_image, to_slot: source_image }
+  - id: animate
+    label: "Animate"
+    target_workflow: wan22_i2v
+    map:
+      - { from_output: output_image, to_slot: init_image }

--- a/workflows/manifests/qwen_image_edit_2511_3images.yaml
+++ b/workflows/manifests/qwen_image_edit_2511_3images.yaml
@@ -1,0 +1,148 @@
+schema_version: 1
+id: qwen_image_edit_2511_3images
+name: "Qwen-Image-Edit 2511 (3 images)"
+description: |
+  Qwen-Image-Edit 2511 4-step Lightning, three-image variant. Same
+  graph as the 1-image manifest plus a second and third ``LoadImage``
+  node whose pixels are fed directly to ``image2`` / ``image3`` of the
+  positive and negative ``TextEncodeQwenImageEditPlus`` nodes. The
+  first image still drives ``VAEEncode`` and therefore the KSampler's
+  latent; images 2 and 3 act purely as references for the edit
+  instruction (e.g. "subject of image 1, hat from image 2, background
+  from image 3").
+modality: image_edit
+workflow_file: workflows/qwen_image_edit_2511_3images.json
+
+requires:
+  unets:
+    - qwen_image_edit_2511_fp8mixed.safetensors
+  vaes:
+    - qwen_image_vae.safetensors
+  clips:
+    - qwen_2.5_vl_7b_fp8_scaled.safetensors
+  loras:
+    - Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors
+    - QWEN_EDIT_ACTION_V1.safetensors
+
+slots:
+  - name: prompt
+    type: text
+    role: prompt_positive
+    target: { node: "12", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Edit instruction"
+      placeholder: "Subject from image 1, attire from image 2, scene from image 3"
+      required: true
+    validation:
+      min_length: 1
+      max_length: 2000
+
+  - name: negative_prompt
+    type: text
+    role: prompt_negative
+    target: { node: "11", field: "prompt" }
+    ui:
+      hint: long_text
+      label: "Negative prompt"
+      default: ""
+      required: false
+    validation:
+      max_length: 2000
+
+  - name: image_1
+    type: image
+    role: source_image
+    target: { node: "8", field: "image" }
+    ui:
+      hint: image
+      label: "Source image 1 (primary)"
+      attachment_position: 1
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: image_2
+    type: image
+    role: source_image_2
+    target: { node: "16", field: "image" }
+    ui:
+      hint: image
+      label: "Source image 2 (reference)"
+      attachment_position: 2
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: image_3
+    type: image
+    role: source_image_3
+    target: { node: "17", field: "image" }
+    ui:
+      hint: image
+      label: "Source image 3 (reference)"
+      attachment_position: 3
+      required: true
+    validation:
+      accepts:
+        - image/png
+        - image/jpeg
+        - image/webp
+
+  - name: seed
+    type: seed
+    role: seed
+    target: { node: "13", field: "seed" }
+    ui:
+      hint: seed
+      label: "Seed"
+      default: random
+      required: false
+
+  - name: lora
+    type: enum_dynamic
+    role: lora
+    target: { node: "5", field: "lora_name" }
+    options_from: comfyui.loras
+    ui:
+      hint: select
+      label: "User LoRA"
+      default: QWEN_EDIT_ACTION_V1.safetensors
+      required: false
+
+  - name: lora_strength
+    type: float
+    role: lora_strength
+    target: { node: "5", field: "strength_model" }
+    ui:
+      hint: number
+      label: "User LoRA strength"
+      default: 0.0
+      step: 0.1
+      required: false
+    validation:
+      min: 0.0
+      max: 2.0
+
+outputs:
+  - role: output_image
+    node: "15"
+    media: image/png
+
+actions:
+  - id: upscale
+    label: "Upscale 2x"
+    target_workflow: image_upscale_latent
+    map:
+      - { from_output: output_image, to_slot: source_image }
+  - id: animate
+    label: "Animate"
+    target_workflow: wan22_i2v
+    map:
+      - { from_output: output_image, to_slot: init_image }

--- a/workflows/qwen_image_edit_2511_1image.json
+++ b/workflows/qwen_image_edit_2511_1image.json
@@ -1,0 +1,167 @@
+{
+  "1": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2511_fp8mixed.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Qwen-Image-Edit-2511 UNET"
+    }
+  },
+  "2": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load Qwen 2.5 VL CLIP"
+    }
+  },
+  "3": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Qwen-Image VAE"
+    }
+  },
+  "4": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1.0,
+      "model": ["1", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "Lightning 4-step LoRA"
+    }
+  },
+  "5": {
+    "inputs": {
+      "lora_name": "QWEN_EDIT_ACTION_V1.safetensors",
+      "strength_model": 0.0,
+      "model": ["4", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "User LoRA (stacked)"
+    }
+  },
+  "6": {
+    "inputs": {
+      "shift": 3.0,
+      "model": ["5", 0]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "7": {
+    "inputs": {
+      "strength": 1.0,
+      "model": ["6", 0]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "8": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 1"
+    }
+  },
+  "9": {
+    "inputs": {
+      "image": ["8", 0],
+      "upscale_method": "lanczos",
+      "megapixels": 1.5,
+      "resolution_steps": 1
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale Source 1 to ~1.5 MP"
+    }
+  },
+  "10": {
+    "inputs": {
+      "pixels": ["9", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "VAE Encode Source 1"
+    }
+  },
+  "11": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Negative Conditioning"
+    }
+  },
+  "12": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Positive Conditioning (edit instruction)"
+    }
+  },
+  "13": {
+    "inputs": {
+      "seed": 0,
+      "steps": 4,
+      "cfg": 1.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": ["7", 0],
+      "positive": ["12", 0],
+      "negative": ["11", 0],
+      "latent_image": ["10", 0]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler (4-step Lightning)"
+    }
+  },
+  "14": {
+    "inputs": {
+      "samples": ["13", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "images": ["14", 0],
+      "filename_prefix": "qwen_edit_2511"
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/workflows/qwen_image_edit_2511_2images.json
+++ b/workflows/qwen_image_edit_2511_2images.json
@@ -1,0 +1,178 @@
+{
+  "1": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2511_fp8mixed.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Qwen-Image-Edit-2511 UNET"
+    }
+  },
+  "2": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load Qwen 2.5 VL CLIP"
+    }
+  },
+  "3": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Qwen-Image VAE"
+    }
+  },
+  "4": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1.0,
+      "model": ["1", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "Lightning 4-step LoRA"
+    }
+  },
+  "5": {
+    "inputs": {
+      "lora_name": "QWEN_EDIT_ACTION_V1.safetensors",
+      "strength_model": 0.0,
+      "model": ["4", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "User LoRA (stacked)"
+    }
+  },
+  "6": {
+    "inputs": {
+      "shift": 3.0,
+      "model": ["5", 0]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "7": {
+    "inputs": {
+      "strength": 1.0,
+      "model": ["6", 0]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "8": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 1"
+    }
+  },
+  "9": {
+    "inputs": {
+      "image": ["8", 0],
+      "upscale_method": "lanczos",
+      "megapixels": 1.5,
+      "resolution_steps": 1
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale Source 1 to ~1.5 MP"
+    }
+  },
+  "10": {
+    "inputs": {
+      "pixels": ["9", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "VAE Encode Source 1"
+    }
+  },
+  "11": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0],
+      "image2": ["16", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Negative Conditioning"
+    }
+  },
+  "12": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0],
+      "image2": ["16", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Positive Conditioning (edit instruction)"
+    }
+  },
+  "13": {
+    "inputs": {
+      "seed": 0,
+      "steps": 4,
+      "cfg": 1.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": ["7", 0],
+      "positive": ["12", 0],
+      "negative": ["11", 0],
+      "latent_image": ["10", 0]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler (4-step Lightning)"
+    }
+  },
+  "14": {
+    "inputs": {
+      "samples": ["13", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "images": ["14", 0],
+      "filename_prefix": "qwen_edit_2511"
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "16": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 2"
+    }
+  }
+}

--- a/workflows/qwen_image_edit_2511_3images.json
+++ b/workflows/qwen_image_edit_2511_3images.json
@@ -1,0 +1,189 @@
+{
+  "1": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2511_fp8mixed.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Qwen-Image-Edit-2511 UNET"
+    }
+  },
+  "2": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load Qwen 2.5 VL CLIP"
+    }
+  },
+  "3": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load Qwen-Image VAE"
+    }
+  },
+  "4": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1.0,
+      "model": ["1", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "Lightning 4-step LoRA"
+    }
+  },
+  "5": {
+    "inputs": {
+      "lora_name": "QWEN_EDIT_ACTION_V1.safetensors",
+      "strength_model": 0.0,
+      "model": ["4", 0]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "User LoRA (stacked)"
+    }
+  },
+  "6": {
+    "inputs": {
+      "shift": 3.0,
+      "model": ["5", 0]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "7": {
+    "inputs": {
+      "strength": 1.0,
+      "model": ["6", 0]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "8": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 1"
+    }
+  },
+  "9": {
+    "inputs": {
+      "image": ["8", 0],
+      "upscale_method": "lanczos",
+      "megapixels": 1.5,
+      "resolution_steps": 1
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "Scale Source 1 to ~1.5 MP"
+    }
+  },
+  "10": {
+    "inputs": {
+      "pixels": ["9", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "VAE Encode Source 1"
+    }
+  },
+  "11": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0],
+      "image2": ["16", 0],
+      "image3": ["17", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Negative Conditioning"
+    }
+  },
+  "12": {
+    "inputs": {
+      "prompt": "",
+      "clip": ["2", 0],
+      "vae": ["3", 0],
+      "image1": ["9", 0],
+      "image2": ["16", 0],
+      "image3": ["17", 0]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "Positive Conditioning (edit instruction)"
+    }
+  },
+  "13": {
+    "inputs": {
+      "seed": 0,
+      "steps": 4,
+      "cfg": 1.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": ["7", 0],
+      "positive": ["12", 0],
+      "negative": ["11", 0],
+      "latent_image": ["10", 0]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler (4-step Lightning)"
+    }
+  },
+  "14": {
+    "inputs": {
+      "samples": ["13", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "images": ["14", 0],
+      "filename_prefix": "qwen_edit_2511"
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "16": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 2"
+    }
+  },
+  "17": {
+    "inputs": {
+      "image": "placeholder.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Source Image 3"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Slice 3a covers the **Qwen-Image-Edit 2511** half of issue #5. The
FLUX Kontext on Klein half is **deferred to a follow-up issue / PR**
because it is gated on Slice 2 fixing the FLUX 2 Klein workflow first.
Issue #5 stays open after this PR merges; the follow-up PR will close
it.

Closes **part of #5**.

- New `image_edit` Modality with one shared Plugin
  (`core/modalities/image_edit/plugin.py`) - slot-value validation,
  stepped progress mapper, Discord renderer that surfaces the edit
  instruction + every source-image slot + seed + output, default
  post-actions echoing the Manifest's declared Actions (upscale +
  animate are valid follow-ups for an edit Run).
- Three Qwen-Image-Edit 2511 manifests for 1 / 2 / 3 input images.
  All three share the same loader + sampler graph and differ only in
  the number of `LoadImage` nodes wired into the
  `TextEncodeQwenImageEditPlus` conditioning's `image2` / `image3`
  inputs. Lightning 4-step LoRA is baked at node 4; a user-stack LoRA
  at node 5 defaults to strength `0.0`.
- All workflow JSONs were built by introspecting `/object_info` on
  the live ComfyUI; the only loader filenames in any of them are the
  exact strings that `/object_info` advertises, and the manifest
  `requires` blocks declare those exact strings.
- No new `Role` values were needed: `source_image`,
  `source_image_2`, and `source_image_3` already existed in
  `core/manifest/roles.py`. `Modality.IMAGE_EDIT` was already present
  too (anticipated by ADR-0002).

## Models used (from live `/object_info`)

- **UNET:** `qwen_image_edit_2511_fp8mixed.safetensors`
- **CLIP:** `qwen_2.5_vl_7b_fp8_scaled.safetensors` (`type: qwen_image`)
- **VAE:** `qwen_image_vae.safetensors`
- **Lightning LoRA:** `Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors`
- **User LoRA default:** `QWEN_EDIT_ACTION_V1.safetensors` (strength 0.0)

## Acceptance criteria

- [x] `Modality.IMAGE_EDIT = "image_edit"` present (it already was).
- [x] Reuses existing Roles (`source_image`, `source_image_2`,
      `source_image_3`); no new Role added. (See
      `core/manifest/roles.py`.)
- [x] `ImageEditPlugin` validates slot values, exposes a progress
      mapper that sums sampler steps across nodes, renders Outputs
      into a Discord embed, returns Manifest-declared default
      Actions.
- [x] Plugin registered in `core.modalities.default_registry`
      (verified by `tests/test_image_edit_plugin.py::test_registered_in_default_registry`).
- [x] Three workflow JSONs grounded in `/object_info`, not copied
      from v2 (`workflows/qwen_image_edit_2511_{1image,2images,3images}.json`).
- [x] Three manifests with exact `requires` filenames + slots for
      `prompt`, `negative_prompt`, `image_1[/image_2/image_3]`,
      `seed`, `lora`, `lora_strength`
      (`workflows/manifests/qwen_image_edit_2511_*.yaml`).
- [x] Unit tests: `tests/test_image_edit_plugin.py` +
      `tests/test_qwen_edit_manifest_loading.py` (44 new tests).
- [x] Full `pytest` (excluding `tests/integration`) green:
      **368 passed**.
- [x] Live smoke against `http://172.27.1.165:8188` PASSED for **all
      three variants**.

## Live smoke evidence

Source images were generated via the existing `qwen_image_2512`
manifest first, then fed into each edit variant. Full details +
reproduction commands in `docs/v3/smoke/SLICE_3_RUNS.md`.

| variant | prompt_id | latency | output bytes |
| --- | --- | --- | --- |
| `qwen_image_edit_2511_1image` | `f46e87b3-19a8-41f6-8a97-d5aa5cf9aaf2` | 21.77 s | 2,333,633 |
| `qwen_image_edit_2511_2images` | `8f1e061c-2526-408a-aa81-77ce8b4865da` | 17.14 s | 1,896,280 |
| `qwen_image_edit_2511_3images` | `eeb3bf7a-1747-4750-8f87-5a1c0e2d5d14` | 20.47 s | 2,139,755 |

ComfyUI: RTX 5090, fp8 mixed UNET, 4-step Lightning sampling.

## Anchors

- **PRD:** `docs/v3/PRD.md` -- "image edit (1-3 inputs)" item in the
  v3 ship list.
- **ADR-0001:** workflow-manifest format (every slot is data, not
  code; `requires` validated against `/object_info`).
- **ADR-0002:** Plugin Protocol contract (one Plugin per Modality).

## Deferred work (NOT in this PR)

- **FLUX Kontext on Klein** -- the other half of #5. Blocked on Slice
  2 (FLUX 2 Klein workflow fix). Will be a follow-up issue + PR. Do
  not close #5 when this PR merges.

## Worktree note

This branch was implemented from the worktree at
`/Users/jamievanderpijll/discomfy-slice-3-qwen` (Slice 4 surfaced a
clobber risk when working directly in the main checkout). The
worktree's `venv` is a symlink to the main repo's `venv`, so no
duplicate environment was created.

## Test plan

- [x] `pytest -q --ignore=tests/integration` -> 368 passed.
- [x] `pytest tests/test_image_edit_plugin.py tests/test_qwen_edit_manifest_loading.py -x -q` -> 44 passed.
- [x] `python scripts/v3_smoke.py --manifest qwen_image_edit_2511_1image --slot prompt="..." --slot image_1=...` -> OK.
- [x] `python scripts/v3_smoke.py --manifest qwen_image_edit_2511_2images --slot prompt="..." --slot image_1=... --slot image_2=...` -> OK.
- [x] `python scripts/v3_smoke.py --manifest qwen_image_edit_2511_3images --slot prompt="..." --slot image_1=... --slot image_2=... --slot image_3=...` -> OK.


Made with [Cursor](https://cursor.com)